### PR TITLE
tctl: Changing the defaults through configuration file [p1]

### DIFF
--- a/cli/002-cli-config-file.md
+++ b/cli/002-cli-config-file.md
@@ -3,7 +3,6 @@
 - Issue:
 
 ### Config file for tctl defaults
-As a user i want to be able to change the defaults of some flags, such as the default namespace.
 Support configuring some of the tctl defaults through a configuration file. 
 
 Add `config` top level command that should allow setting and reading specific config options

--- a/cli/002-cli-config-file.md
+++ b/cli/002-cli-config-file.md
@@ -1,0 +1,19 @@
+- Start Date: 2021-06-11
+- RFC PR:
+- Issue:
+
+### Config file for tctl defaults
+As a user i want to be able to change the defaults of some flags, such as the default namespace.
+Support configuring some of the tctl defaults through a configuration file. 
+
+Add `config` top level command that should allow setting and reading specific config options
+
+ Use XDG-spec to locate the config file:
+ ~/.config/tctl on Unix
+ %LOCALAPPDATA%\tctl on Windows
+
+For start, support the equivalents of the following tctl flags:
+ - Namespace name `--namespace`
+ - Temporal frontend service address `--address`
+ - Data converter plugin path `--data-converter-plugin`
+ - RPC context timeout `--context_timeout`

--- a/cli/002-cli-config-file.md
+++ b/cli/002-cli-config-file.md
@@ -17,4 +17,4 @@ For start, support the equivalents of the following tctl flags:
  - Namespace name `--namespace`
  - Temporal frontend service address `--address`
  - Data converter plugin path `--data-converter-plugin`
- - RPC context timeout `--context_timeout`
+ - RPC context timeout `--context-timeout`

--- a/cli/002-cli-config-file.md
+++ b/cli/002-cli-config-file.md
@@ -9,8 +9,10 @@ Support configuring some of the tctl defaults through a configuration file.
 Add `config` top level command that should allow setting and reading specific config options
 
  Use XDG-spec to locate the config file:
- ~/.config/tctl on Unix
- %LOCALAPPDATA%\tctl on Windows
+ 
+ `~/.config/tctl` on Unix
+ 
+ `%LOCALAPPDATA%\tctl` on Windows
 
 For start, support the equivalents of the following tctl flags:
  - Namespace name `--namespace`


### PR DESCRIPTION
- Origin issue: 

# Summary

Allows changing tctl defaults through a new `config` command. Stores the defaults in configuration file  

# Basic example

``` bash
tctl config set namespace custom-namespace
```

equivalent with explicit flags:
``` bash
tctl config set --property namespace --value custom-namespace
```

# Motivation

Allows to set some of the flags once and not have to specify them every-time. This is especially relevant for the flags that often remain the same through time, are required in many commands such as --namespace

# Detailed design

in doc

# Drawbacks

# Alternatives

- ensuring that all such configs can be set through env variables

# Adoption strategy

Not a breaking change. Provide good `--help` for the new `config` command. Document in docs 

# Unresolved questions