### PR TITLE
tctl: Support commands auto-completion

### DIFF
--- a/cli/003-cli-autocomplete.md
+++ b/cli/003-cli-autocomplete.md
@@ -1,0 +1,11 @@
+- Start Date: 2021-06-11
+- RFC PR:
+- Issue:
+
+### Commands auto-completion
+Support auto-completion of commands in bash. Lesser priority - zsh.
+
+- Pressing Tab when a command/flag is partially typed and there is only one candidate should auto-complete it.
+- Pressing Tab when there are multiple candidates should output the candidates and allow to continue typing.
+
+Add a command `completion` to output the completion script. Command name and behavior is taken from similar cases in `kubectl` and `gh` to "build on potential user's expected knowledge" per UNIX philosophy


### PR DESCRIPTION
- Origin issue: 

# Summary

Allows users to enable commands auto-completion in bash

# Basic example

``` bash
source <(tctl completion bash)
```

# Motivation

Reduces the effort to type commands

# Detailed design

in doc

# Drawbacks

in terms of UX this is rather a low-medium priority feature, as there are other ways to simplify the effort

# Alternatives

- short versions of commands
- some terminal shells provide similar functionality out of the box (ex. nushell)

# Adoption strategy

Provide a good `--help` output for the new command `completion` 

# How we teach this

Terminology: CLI auto-completion

# Unresolved questions

Optional, but suggested for first drafts. What parts of the design are still
TBD?