### PR TITLE
tctl: Consistent Output formatting as tables, json, cards [p0]

### DIFF
--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -4,7 +4,7 @@
 
 ### Improve commands output UX and rendering options
 
-##### many commands do not support switching between Table and JSON views.
+#### Many commands do not support switching between Table and JSON views.
 
 In places where we retrieve and print entity objects, support changing how the objects are printed through `--json` and `--table` flags. For arrays of objects, usually prefer Table view as the default. Implement the proposal by creating a unified rendering utility.
 

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -8,17 +8,18 @@ Current Issues and improvement proposals:
 
 #### - Many commands do not support switching between Table and JSON views.
 
-In places where we retrieve and print entity objects, support changing how the objects are printed through `--json` and `--table` flags. For arrays of objects, usually prefer Table view as the default. Implement the proposal by creating a unified rendering utility.
-``` bash
-tctl workflow list --table # default for most commands
-tctl workflow list --json
-```
+In places where we retrieve and print entity objects, support changing how the objects are printed through `--format` flag that accepts the following values:
+- `--format table` # default for most commands
+- `--format json`
+- `--format card` # new view
 
-#### - All commands do not support printing data in a form of cards (`{field name} {field value}` per row), which is especially useful in combination with `grep` or when describing a single object.
+For arrays of objects, usually prefer Table view as the default. Implement the proposal by creating a unified rendering utility.
 
-Add `--card` flag that will print entity object in a format `{field name} {field value}`.
+#### - All commands do not support printing data in a form of cards (`{field name}: {field value}` per row), which is especially useful in combination with `grep` or when describing a single object.
+
+Add `--format card` key that will print entity object in a format `{field name}: {field value}`.
 ``` bash
-tctl workflow list --card | grep WorkflowId
+tctl workflow list --format card | grep WorkflowId
 ```
 
 #### - Output is often noisy, single entity row may spill to the next rows and break the tables.

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -8,30 +8,30 @@ Current Issues and improvement proposals:
 
 #### - Many commands do not support switching between Table and JSON views.
 
-In places where we retrieve and print entity objects, support changing how the objects are printed through `--format` flag that accepts the following values:
-- `--format table` # default for most commands
-- `--format json`
-- `--format card` # new view
+In places where we retrieve and print entity objects, support changing how the objects are printed through `--output` flag that accepts the following values:
+- `--output table` # default for most commands
+- `--output json`
+- `--output card` # new view
 
 For arrays of objects, usually prefer Table view as the default. Implement the proposal by creating a unified rendering utility.
 
 #### - All commands do not support printing data in a form of cards (`{field name}: {field value}` per row), which is especially useful in combination with `grep` or when describing a single object.
 
-Add `--format card` key that will print entity object in a format `{field name}: {field value}`.
+Add `--output card` key that will print entity object in a format `{field name}: {field value}`.
 ``` bash
-tctl workflow list --format card | grep WorkflowId
-```
-
-#### - Output is often noisy, single entity row may spill to the next rows and break the tables.
-
-Change the list commands to output 3-5 columns/fields by default. Add `--long` flag that will add few more of the ~most important fields. This behavior is similar to `nushell`'s `ls --long` flag
-``` bash
-tctl workflow list --long
+tctl workflow list --output card | grep WorkflowId
 ```
 
 #### - Limited support for changing the columns/fields in Table view. Only specific fields are explicitly supported through flags, ex. `--print_memo`.
 
-Proposal: Add `--field` flag so users can customize the fields to output in Table/Card. Add `--fields` flag to examine and print all available field names for --field input. If a field passed with `--field` is not found, then notify the user and print the result of `--fields` as a suggestion. 
+Proposal: Add `--columns` flag so users can customize the columns to output in Table/Card. The flag should accept comma separated list of field names. Not passing a value into `--columns` or passing a wrong field name should print an error message plus all of the available fields.  
 ``` bash
-tctl workflow list --field Execution.RunId --field searchAttributes
+tctl workflow list --columns "Execution.RunId, searchAttributes"
+```
+
+#### - Output is often noisy, single entity row may spill to the next rows and break the tables.
+
+Change the list commands to output 3-5 columns/fields by default. Add a special case value `long` for `--columns` flag that will add few more of the ~most important fields. This behavior is similar to `nushell`'s `ls --long` flag
+``` bash
+tctl workflow list --columns long
 ```

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -4,17 +4,19 @@
 
 ### Improve commands output UX and rendering options
 
+Issues (bold) and proposals:
+
 #### - Many commands do not support switching between Table and JSON views.
 
 In places where we retrieve and print entity objects, support changing how the objects are printed through `--json` and `--table` flags. For arrays of objects, usually prefer Table view as the default. Implement the proposal by creating a unified rendering utility.
 
 
-##### all commands do not support printing data in a form of cards (`{field name} {field value}` per row), which is especially useful in combination with `grep` or when describing a single object.
+#### - All commands do not support printing data in a form of cards (`{field name} {field value}` per row), which is especially useful in combination with `grep` or when describing a single object.
 
 Add `--card` flag that will print entity object in a format `{field name} {field value}`.
 
 
-##### output is often noisy, single entity row may spill to the next rows and break the tables.
+#### - Output is often noisy, single entity row may spill to the next rows and break the tables.
 
 Change the list commands to output 3-5 columns/fields by default. Add `--details` flag that will add few more of the ~most important fields. This behavior is similar to `nushell`'s `ls --long` flag
 
@@ -23,7 +25,7 @@ Example:
 tctl workflow list --details
 ```
 
-##### limited support for changing the columns/fields in Table view. Only specific fields are explicitly supported through flags, ex. `--print_memo`.
+#### - Limited support for changing the columns/fields in Table view. Only specific fields are explicitly supported through flags, ex. `--print_memo`.
 
 Proposal: Add `--field` flag so users can customize the fields to output in Table/Card (can be passed ). Add `--fields` flag to examine and print all available field names for --field input. If a field passed with `--field` is not found, then notify the user and print the result of `--fields` as a suggestion. 
 

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -8,7 +8,7 @@
 
 Proposal: in places where we retrieve and print entity objects, support changing how the objects are printed through `--json` and `--table` flags. For arrays of objects, usually prefer Table view as the default. Implement the proposal by creating a unified rendering utility.
 
-- All commands do not support printing data in a form of cards (`{field name} {field value}` per row), which is especially useful in combination with `grep` or when printing a single object.
+- All commands do not support printing data in a form of cards (`{field name} {field value}` per row), which is especially useful in combination with `grep` or when describing a single object.
 
 Proposal: Add `--card` flag that will print entity object in a format `{field name} {field value}`.
 

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -4,7 +4,7 @@
 
 ### Improve commands output UX and rendering options
 
-Issues (bold) and proposals:
+Current Issues and improvement proposals:
 
 #### - Many commands do not support switching between Table and JSON views.
 

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -26,7 +26,7 @@ tctl workflow list --format card | grep WorkflowId
 
 Change the list commands to output 3-5 columns/fields by default. Add `--long` flag that will add few more of the ~most important fields. This behavior is similar to `nushell`'s `ls --long` flag
 ``` bash
-tctl workflow list --details
+tctl workflow list --long
 ```
 
 #### - Limited support for changing the columns/fields in Table view. Only specific fields are explicitly supported through flags, ex. `--print_memo`.

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -24,7 +24,7 @@ tctl workflow list --format card | grep WorkflowId
 
 #### - Output is often noisy, single entity row may spill to the next rows and break the tables.
 
-Change the list commands to output 3-5 columns/fields by default. Add `--details` flag that will add few more of the ~most important fields. This behavior is similar to `nushell`'s `ls --long` flag
+Change the list commands to output 3-5 columns/fields by default. Add `--long` flag that will add few more of the ~most important fields. This behavior is similar to `nushell`'s `ls --long` flag
 ``` bash
 tctl workflow list --details
 ```

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -1,0 +1,27 @@
+- Start Date: 2021-06-11
+- RFC PR:
+- Issue:
+
+### Improve commands output UX and rendering options
+
+- many commands do not support switching between Table and JSON views. ~All commands to not support printing data in a form of cards (`{field name} {field value}`), which is especially useful for `grep`.
+
+Proposal:
+
+- limited support for changing the columns/fields in Table view. Only specific fields are explicitly supported through flags, ex. `--print_memo`.
+
+- Output is sometimes noisy, single entity row may spill to the next rows and break the tables.
+
+Change the list commands to output 3-5 columns/fields by default. Add `--details` flag that will add few more of the ~most important fields. This behavior is similar to `nushell`'s `ls --long` flag
+
+Example:
+``` bash
+tctl workflow list --details
+```
+
+Add `--field` flag so users can customize the fields to output in Table/Card (can be passed ). Add `--fields` flag to examine and print all available field names for --field input. If a field passed with `--field` is not found, then notify the user and print the result of `--fields` as a suggestion. 
+
+Example:
+``` bash
+tctl workflow list --field Execution.RunId --field searchAttributes
+```

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -4,13 +4,15 @@
 
 ### Improve commands output UX and rendering options
 
-- many commands do not support switching between Table and JSON views. ~All commands to not support printing data in a form of cards (`{field name} {field value}`), which is especially useful for `grep`.
+- many commands do not support switching between Table and JSON views.
 
-Proposal:
+Proposal: in places where we retrieve and print entity objects, support changing how the objects are printed through `--json` and `--table` flags. For arrays of objects, usually prefer Table view as the default. Implement the proposal by creating a unified rendering utility.
 
-- limited support for changing the columns/fields in Table view. Only specific fields are explicitly supported through flags, ex. `--print_memo`.
+- All commands do not support printing data in a form of cards (`{field name} {field value}` per row), which is especially useful in combination with `grep` or when printing a single object.
 
-- Output is sometimes noisy, single entity row may spill to the next rows and break the tables.
+Proposal: Add `--card` flag that will print entity object in a format `{field name} {field value}`.
+
+- Output is often noisy, single entity row may spill to the next rows and break the tables.
 
 Change the list commands to output 3-5 columns/fields by default. Add `--details` flag that will add few more of the ~most important fields. This behavior is similar to `nushell`'s `ls --long` flag
 
@@ -19,7 +21,9 @@ Example:
 tctl workflow list --details
 ```
 
-Add `--field` flag so users can customize the fields to output in Table/Card (can be passed ). Add `--fields` flag to examine and print all available field names for --field input. If a field passed with `--field` is not found, then notify the user and print the result of `--fields` as a suggestion. 
+- limited support for changing the columns/fields in Table view. Only specific fields are explicitly supported through flags, ex. `--print_memo`.
+
+Proposal: Add `--field` flag so users can customize the fields to output in Table/Card (can be passed ). Add `--fields` flag to examine and print all available field names for --field input. If a field passed with `--field` is not found, then notify the user and print the result of `--fields` as a suggestion. 
 
 Example:
 ``` bash

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -4,15 +4,17 @@
 
 ### Improve commands output UX and rendering options
 
-- many commands do not support switching between Table and JSON views.
+##### many commands do not support switching between Table and JSON views.
 
-Proposal: in places where we retrieve and print entity objects, support changing how the objects are printed through `--json` and `--table` flags. For arrays of objects, usually prefer Table view as the default. Implement the proposal by creating a unified rendering utility.
+In places where we retrieve and print entity objects, support changing how the objects are printed through `--json` and `--table` flags. For arrays of objects, usually prefer Table view as the default. Implement the proposal by creating a unified rendering utility.
 
-- All commands do not support printing data in a form of cards (`{field name} {field value}` per row), which is especially useful in combination with `grep` or when describing a single object.
 
-Proposal: Add `--card` flag that will print entity object in a format `{field name} {field value}`.
+##### all commands do not support printing data in a form of cards (`{field name} {field value}` per row), which is especially useful in combination with `grep` or when describing a single object.
 
-- Output is often noisy, single entity row may spill to the next rows and break the tables.
+Add `--card` flag that will print entity object in a format `{field name} {field value}`.
+
+
+##### output is often noisy, single entity row may spill to the next rows and break the tables.
 
 Change the list commands to output 3-5 columns/fields by default. Add `--details` flag that will add few more of the ~most important fields. This behavior is similar to `nushell`'s `ls --long` flag
 
@@ -21,7 +23,7 @@ Example:
 tctl workflow list --details
 ```
 
-- limited support for changing the columns/fields in Table view. Only specific fields are explicitly supported through flags, ex. `--print_memo`.
+##### limited support for changing the columns/fields in Table view. Only specific fields are explicitly supported through flags, ex. `--print_memo`.
 
 Proposal: Add `--field` flag so users can customize the fields to output in Table/Card (can be passed ). Add `--fields` flag to examine and print all available field names for --field input. If a field passed with `--field` is not found, then notify the user and print the result of `--fields` as a suggestion. 
 

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -4,7 +4,7 @@
 
 ### Improve commands output UX and rendering options
 
-#### Many commands do not support switching between Table and JSON views.
+#### - Many commands do not support switching between Table and JSON views.
 
 In places where we retrieve and print entity objects, support changing how the objects are printed through `--json` and `--table` flags. For arrays of objects, usually prefer Table view as the default. Implement the proposal by creating a unified rendering utility.
 

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -31,7 +31,7 @@ tctl workflow list --details
 
 #### - Limited support for changing the columns/fields in Table view. Only specific fields are explicitly supported through flags, ex. `--print_memo`.
 
-Proposal: Add `--field` flag so users can customize the fields to output in Table/Card (can be passed ). Add `--fields` flag to examine and print all available field names for --field input. If a field passed with `--field` is not found, then notify the user and print the result of `--fields` as a suggestion. 
+Proposal: Add `--field` flag so users can customize the fields to output in Table/Card. Add `--fields` flag to examine and print all available field names for --field input. If a field passed with `--field` is not found, then notify the user and print the result of `--fields` as a suggestion. 
 ``` bash
 tctl workflow list --field Execution.RunId --field searchAttributes
 ```

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -26,7 +26,7 @@ tctl workflow list --output card | grep WorkflowId
 
 Proposal: Add `--columns` flag so users can customize the columns to output in Table/Card. The flag should accept comma separated list of field names. Not passing a value into `--columns` or passing a wrong field name should print an error message plus all of the available fields.  
 ``` bash
-tctl workflow list --columns "Execution.RunId, searchAttributes"
+tctl workflow list --columns Execution.RunId,SearchAttributes
 ```
 
 #### - Output is often noisy, single entity row may spill to the next rows and break the tables.

--- a/cli/006-cli-output-options.md
+++ b/cli/006-cli-output-options.md
@@ -9,18 +9,21 @@ Current Issues and improvement proposals:
 #### - Many commands do not support switching between Table and JSON views.
 
 In places where we retrieve and print entity objects, support changing how the objects are printed through `--json` and `--table` flags. For arrays of objects, usually prefer Table view as the default. Implement the proposal by creating a unified rendering utility.
-
+``` bash
+tctl workflow list --table # default for most commands
+tctl workflow list --json
+```
 
 #### - All commands do not support printing data in a form of cards (`{field name} {field value}` per row), which is especially useful in combination with `grep` or when describing a single object.
 
 Add `--card` flag that will print entity object in a format `{field name} {field value}`.
-
+``` bash
+tctl workflow list --card | grep WorkflowId
+```
 
 #### - Output is often noisy, single entity row may spill to the next rows and break the tables.
 
 Change the list commands to output 3-5 columns/fields by default. Add `--details` flag that will add few more of the ~most important fields. This behavior is similar to `nushell`'s `ls --long` flag
-
-Example:
 ``` bash
 tctl workflow list --details
 ```
@@ -28,8 +31,6 @@ tctl workflow list --details
 #### - Limited support for changing the columns/fields in Table view. Only specific fields are explicitly supported through flags, ex. `--print_memo`.
 
 Proposal: Add `--field` flag so users can customize the fields to output in Table/Card (can be passed ). Add `--fields` flag to examine and print all available field names for --field input. If a field passed with `--field` is not found, then notify the user and print the result of `--fields` as a suggestion. 
-
-Example:
 ``` bash
 tctl workflow list --field Execution.RunId --field searchAttributes
 ```


### PR DESCRIPTION
- Origin issue: 

# Summary

Allows to customize what columns are printed in Table view.

Reduces noise when rendering Tables.

Standardizes control over printing options through `--output` flag

Adds a new printing format option `card` to render objects as `{field name}: {field value}`
 
# Basic example

``` bash
tctl workflow list --output table # default for most commands
tctl workflow list --output json
tctl workflow list --output card # new view
```

``` bash
tctl workflow list --columns Execution.RunId,SearchAttributes # prints table with mentioned columns
tctl workflow list --columns long # automatically add more columns
```
# Motivation

Improves and standardizes UX related to printing of data 

# Detailed design

in doc

# Drawbacks

One important breaking change is the change of `--print_json` flag to `--output json`. The rest is addition

# Alternatives

# Adoption strategy

Notify community about tctl the breaking change

# How we teach this

`--help` and docs

# Unresolved questions
Is backwards compatibility needed?