### PR TITLE
tctl: Consistent coloring [p1]

### DIFF
--- a/cli/007-cli-color.md
+++ b/cli/007-cli-color.md
@@ -8,6 +8,6 @@ Good usage of coloring can help users to read the output and direct attention to
 
 - Standartize the colors used in printing
 - Work through commands and improve the coloring
-- add a flag `--no-color` to disable coloring alltogether
+- add a flag `--color` that takes the following values: `auto` (enable in tty/ disable in non-tty), `always`, `disabled` 
 - low priority: colorize command and flag names in `--help` output
 - low priority: add built-in coloring of `--json` output. Piping into `jq` can be used by users as an alternative so low priority.

--- a/cli/007-cli-color.md
+++ b/cli/007-cli-color.md
@@ -9,5 +9,5 @@ Good usage of coloring can help users to read the output and direct attention to
 - Standartize the colors used in printing
 - Work through commands and improve the coloring
 - add a flag `--no-color` to disable coloring alltogether
-- low priority: colorize the command and flag names in `--help` output
+- low priority: colorize command and flag names in `--help` output
 - low priority: add built-in coloring of `--json` output. Piping into `jq` can be used by users as an alternative so low priority.

--- a/cli/007-cli-color.md
+++ b/cli/007-cli-color.md
@@ -1,0 +1,13 @@
+- Start Date: 2021-06-11
+- RFC PR:
+- Issue:
+
+### Better coloring
+
+Good usage of coloring can help users to read the output and direct attention to the most interesting parts.
+
+- Standartize the colors used in printing
+- Work through commands and improve the coloring
+- add a flag `--no-color` to disable coloring alltogether
+- low priority: colorize the command and flag names in `--help` output
+- low priority: add built-in coloring of `--json` output. Piping into `jq` can be used by users as an alternative so low priority.


### PR DESCRIPTION
- Origin issue: 

# Summary

Improves coloring when printing commands outputs.

Allows to disable coloring and increase contrast in the output

# Basic example
``` bash
tctl workflow run --workflow_type wtype --taskqueue queue --color never
```

# Motivation

Brings consistency into what colors are used and when. Allows to disable coloring 

# Detailed design

in doc

# Drawbacks
There are tradeoffs to choosing any path. Attempt to identify them here.

# Alternatives

# Adoption strategy

Not a breaking change. There is going to be an additional flag `--color` visible through `--help`

# How we teach this

Providing a `--help` text for the new flag

# Unresolved questions