### PR TITLE
tctl: Add command examples to --help [p2]

### DIFF
--- a/cli/009-cli-command-examples.md
+++ b/cli/009-cli-command-examples.md
@@ -1,0 +1,17 @@
+- Start Date: 2021-06-11
+- RFC PR:
+- Issue:
+
+### Better coloring
+
+Commands should have concrete examples of usage in the help output.
+
+For example, typing `tctl namespace update --help` should have an example in the output, among the lines of
+
+```
+...
+<help output mentioning arguments, flags etc..>
+Examples
+    $ tctl namespace update --namespace default --description 'my namespace new description'
+    $ tctl namespace update --namespace default --retention 3
+```


### PR DESCRIPTION
- Origin issue: 

# Summary

Adds command examples to `--help`

# Basic example


```
$ tctl namespace update --help

<help output mentioning arguments, flags etc..>
Examples
    $ tctl namespace update --namespace default --description 'my namespace new description'
    $ tctl namespace update --namespace default --retention 3
```

# Motivation

Helps users to use the commands by showing examples

# Detailed design

in doc

# Drawbacks

- slightly more text in `--help` output

# Alternatives

# Adoption strategy

Not a breaking change

# How we teach this

No need

# Unresolved questions
