### PR TITLE
tctl: Format timestamp fields using a flag [p1]

### DIFF
--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -1,0 +1,14 @@
+- Start Date: 2021-06-11
+- RFC PR:
+- Issue:
+
+### Format timestamp fields using a flag
+
+When printing data in `--table` or `--card` views, allow swithing the format of the timestamp fields (ie. `google.protobuf.Timestamp`) 
+
+Add `--time-format` flag with possible values:
+- `relative` to print in a format `6 hours ago`. Use as default format in tty environment
+- `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`. Use as default in non-tty environment
+- `datetime` flag to print in a format `2021-06-16T00:21:24Z` (ie. time.RFC3339)
+- `date` to print in a format `2021-06-15`
+- `time` to print in a format `00:21:24`

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -9,4 +9,4 @@ When printing data in `--table` or `--card` views, allow switching the format of
 Add `--time-format` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment
 - `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`.
-- `iso` flag to print in a format `2021-06-16T00:21:24Z` (ISO 8601, time.RFC3339)
+- `iso` flag to print in a format `2021-06-16T00:21:24Z` (ISO 8601, time.RFC3339). Use as default in non-tty environment

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -9,6 +9,6 @@ When printing data in `--table` or `--card` views, allow switching the format of
 Add `--time-format` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment
 - `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`. Use as default in non-tty environment
-- `datetime` flag to print in a format `2021-06-16T00:21:24Z` (ie. time.RFC3339)
+- `iso` flag to print in a format `2021-06-16T00:21:24Z` (ISO 8601, time.RFC3339)
 - `date` to print in a format `2021-06-15`
 - `time` to print in a format `00:21:24`

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -10,5 +10,4 @@ Add `--format-time` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment
 - `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`.
 - `iso` to print in a format `2021-06-16T00:21:24.667Z` (ISO 8601, time.RFC3339). Use as default in non-tty environment
-- `tz=utc` to print for specific timezone
 - `Jan 2 15:04:05 2006 MST` # ie. custom format using https://golang.org/pkg/time/#Time.Format

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -10,4 +10,4 @@ Add `--time-format` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment
 - `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`.
 - `iso` flag to print in a format `2021-06-16T00:21:24Z` (ISO 8601, time.RFC3339). Use as default in non-tty environment
-- `Jan 2 15:04:05 2006 MST` # ie. custom format
+- `Jan 2 15:04:05 2006 MST` # ie. custom format using https://golang.org/pkg/time/#Time.Format

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -9,6 +9,6 @@ When printing data in `--table` or `--card` views, allow switching the format of
 Add `--format-time` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment
 - `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`.
-- `iso` to print in a format `2021-06-16T00:21:24Z` (ISO 8601, time.RFC3339). Use as default in non-tty environment
+- `iso` to print in a format `2021-06-16T00:21:24.667Z` (ISO 8601, time.RFC3339). Use as default in non-tty environment
 - `tz=utc` to print for specific timezone
 - `Jan 2 15:04:05 2006 MST` # ie. custom format using https://golang.org/pkg/time/#Time.Format

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -4,7 +4,7 @@
 
 ### Format timestamp fields using a flag
 
-When printing data in `--table` or `--card` views, allow swithing the format of the timestamp fields (ie. `google.protobuf.Timestamp`) 
+When printing data in `--table` or `--card` views, allow switching the format of the timestamp fields (ie. `google.protobuf.Timestamp`) 
 
 Add `--time-format` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -6,7 +6,7 @@
 
 When printing data in `--table` or `--card` views, allow switching the format of the timestamp fields (ie. `google.protobuf.Timestamp`) 
 
-Add `--format-time` flag with possible values:
+Add `--time-format` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment
 - `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`.
 - `iso` to print in a format `2021-06-16T00:21:24.667Z` (ISO 8601, time.RFC3339). Use as default in non-tty environment

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -10,3 +10,4 @@ Add `--time-format` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment
 - `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`.
 - `iso` flag to print in a format `2021-06-16T00:21:24Z` (ISO 8601, time.RFC3339). Use as default in non-tty environment
+- `Jan 2 15:04:05 2006 MST` # ie. custom format

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -8,5 +8,5 @@ When printing data in `--table` or `--card` views, allow switching the format of
 
 Add `--time-format` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment
-- `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`. Use as default in non-tty environment
+- `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`.
 - `iso` flag to print in a format `2021-06-16T00:21:24Z` (ISO 8601, time.RFC3339)

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -10,5 +10,3 @@ Add `--time-format` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment
 - `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`. Use as default in non-tty environment
 - `iso` flag to print in a format `2021-06-16T00:21:24Z` (ISO 8601, time.RFC3339)
-- `date` to print in a format `2021-06-15`
-- `time` to print in a format `00:21:24`

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -6,7 +6,7 @@
 
 When printing data in `--table` or `--card` views, allow switching the format of the timestamp fields (ie. `google.protobuf.Timestamp`) 
 
-Add `--time-format` flag with possible values:
+Add `--format-time` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment
 - `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`.
 - `iso` flag to print in a format `2021-06-16T00:21:24Z` (ISO 8601, time.RFC3339). Use as default in non-tty environment

--- a/cli/010-cli-datetime-format.md
+++ b/cli/010-cli-datetime-format.md
@@ -9,5 +9,6 @@ When printing data in `--table` or `--card` views, allow switching the format of
 Add `--format-time` flag with possible values:
 - `relative` to print in a format `6 hours ago`. Use as default format in tty environment
 - `raw` to print in a format  `2021-06-16 00:21:24.472487365 +0000 UTC`.
-- `iso` flag to print in a format `2021-06-16T00:21:24Z` (ISO 8601, time.RFC3339). Use as default in non-tty environment
+- `iso` to print in a format `2021-06-16T00:21:24Z` (ISO 8601, time.RFC3339). Use as default in non-tty environment
+- `tz=utc` to print for specific timezone
 - `Jan 2 15:04:05 2006 MST` # ie. custom format using https://golang.org/pkg/time/#Time.Format


### PR DESCRIPTION
- Origin issue: 

# Summary

Adds control over how timestamp fields are printed 

# Basic example

``` bash
$ tctl workflow list --time-format relative # default in tty
$ tctl workflow list --time-format iso # default in non-tty
$ tctl workflow list --time-format raw
$ tctl workflow list --time-format "Jan 2 15:04:05 2006 MST" # ie. custom format
```

# Motivation

Helps reading timestamp values in Tables and Cards.
Reduces noise in tty Tables by default, since relative format (`6 hrs ago`) is shorter and less-noisy than others

# Detailed design

in doc

# Drawbacks

Why should we *not* do this? Please consider:

- changes the default format

# Alternatives

What other designs have been considered? What is the impact of not doing this?

# Adoption strategy

Not a breaking change, though changes the default timestamp format 

# How we teach this

`--help` for this flag should be clear and show possible values

# Unresolved questions
