### PR TITLE
Schedule API

### DIFF
--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -14,40 +14,39 @@ import { ScheduleClient, ScheduleOverlapPolicy } from '@temporalio/client'
 import { addWeeks } from 'date-fns'
 import { myWorkflow } from './workflows'
 
-const client = new ScheduleClient()
+const client = new ScheduleClient();
 
 const schedule = await client.create({
   id: 'schedule-biz-id',
   spec: {
     // every hour at minute 5
-    intervals: [{
-      every: '1h',
-      at: '5m',
-    }],
+    intervals: [
+      {
+        every: '1h',
+        at: '5m',
+      },
+    ],
     // every 20 days since epoch at day 2
     // intervals: [{
     //   every: '20d',
     //   at: '2d'
     // }]
-    exclude: [{
-      // skip 11:05 pm
-      hour: 23,
-      minute: 5,
-    }],
-    endAt: addWeeks(new Date(), 4), 
+    skip: [
+      {
+        // skip 11:05 pm
+        hour: 23,
+        minute: 5,
+      },
+    ],
+    endAt: addWeeks(new Date(), 4),
     jitter: '30s',
-    timezone: 'US/Eastern',
   },
   action: {
-    startWorkflow: {
-      workflowId: 'wf-biz-id',
-      type: myWorkflow,
-      args: ['sorry this is the only thing reused, chad 😄'],
-      // ...WorkflowOptions + header - followRuns
-      // https://typescript.temporal.io/api/interfaces/client.WorkflowOptions
-    },
+    workflowId: 'wf-biz-id',
+    type: myWorkflow,
+    args: ['arg1', 'arg2'],
   },
-  overlap: ScheduleOverlapPolicy.BUFFER_ONE,
+  overlap: ScheduleOverlapPolicy.BufferOne,
   catchupWindow: '2m',
   pauseOnFailure: true,
   note: 'started schedule',
@@ -58,44 +57,1132 @@ const schedule = await client.create({
     {
       start: new Date(),
       end: new Date(),
-      overlap: ScheduleOverlapPolicy.ALLOW_ALL,
+      overlap: ScheduleOverlapPolicy.AllowAll,
     },
   ],
   memo,
   searchAttributes,
-})
+});
 
-const schedule = client.getHandle('schedule-biz-id')
+const schedule = client.getHandle('schedule-biz-id');
 
-const scheduleDescription = await schedule.describe()
+const scheduleDescription = await schedule.describe();
 
-const matchingStartTimes = await schedule.listMatchingTimes({ start: new Date(), end: new Date() })
+// For later, pending API finalization:
+// https://github.com/temporalio/proposals/pull/62/files#r933532170
+// const matchingStartTimes = await schedule.listMatchingTimes({ start: new Date(), end: new Date() })
+// const matchingStartTimes = await client.listMatchingTimes({ spec, start, end })
 
-await schedule.update({
-  spec,
-  action,
-  policies,
-  state,
-  conflictToken: scheduleDescription.conflictToken,
-})
+await schedule.update(
+  (schedule) => {
+    schedule.spec.intervals[0].every = '1d';
+    // unset with:
+    // delete schedule.spec.intervals;
 
-await schedule.trigger()
-await schedule.backfill(backfill) // also takes array
-await schedule.pause('note: pausing')
-await schedule.unpause('now unpause')
+    // return false to stop retrying early
+  },
+  { retry: retryPolicy }
+);
 
-await schedule.delete()
+await schedule.trigger();
+await schedule.backfill({ startAt: new Date(), endAt: addWeeks(new Date(), 1) }); // also takes array
+await schedule.pause('note: pausing');
+await schedule.unpause('now unpause');
 
-const { schedules, nextPageToken } = await client.list({
+await schedule.delete();
+
+const { schedules, nextPageToken } = await client.listByPage({
   pageSize: 50,
   nextPageToken: 'base64',
-})
+});
 
-for await (const schedule: ScheduleListEntry of client.list()) {
-  const { id, memo, searchAttributes, info } = schedule
+for await (const schedule: Schedule of client.list()) {
+  const { id, memo, searchAttributes } = schedule;
   // ...
 }
+```
 
+### Types
+
+```ts
+import { DataConverter, LoadedDataConverter } from '@temporalio/common';
+import { loadDataConverter } from '@temporalio/internal-non-workflow-common';
+import {
+  composeInterceptors,
+  Headers,
+  Replace,
+  RetryPolicy,
+  SearchAttributes,
+  Workflow,
+} from '@temporalio/internal-workflow-common';
+import { temporal } from '@temporalio/proto';
+import os from 'os';
+import { Connection } from './connection';
+import { ScheduleClientCallsInterceptor, ScheduleClientInterceptors } from './interceptors';
+import { ConnectionLike, Metadata, WorkflowService } from './types';
+import { WorkflowHandle, WorkflowStartOptions } from './workflow-client';
+
+import type { NonNegativeInteger, RequireAtLeastOne } from 'type-fest';
+
+// TODO is a non-generic NonNegativeInteger possible? The ones below error due to no type argument
+export type PositiveInteger = Exclude<NonNegativeInteger, 0>;
+
+/**
+ * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
+ */
+export type Milliseconds = string | NonNegativeInteger;
+
+/**
+ * @format number of seconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
+ */
+export type Seconds = string | NonNegativeInteger;
+
+export interface UpdateScheduleOptions {
+  /**
+   * @default TODO
+   */
+  retry?: RetryPolicy;
+}
+
+export interface Backfill {
+  /** Time range to evaluate Schedule in. */
+  startAt: Date;
+  endAt: Date;
+
+  /** Override Overlap Policy for this request. */
+  overlapPolicyOverride?: ScheduleOverlapPolicy;
+}
+
+/**
+ * Handle to a single Schedule
+ */
+export interface ScheduleHandle {
+  /**
+   * This Schedule's identifier
+   */
+  readonly id: string;
+
+  /**
+   * Update the Schedule
+   */
+  update(mutateFn: (schedule: ScheduleDescription) => void | false, options?: UpdateScheduleOptions): Promise<void>;
+
+  /**
+   * Delete the Schedule
+   */
+  delete(): Promise<void>;
+
+  /**
+   * Trigger an Action to be taken immediately
+   */
+  trigger(): Promise<void>;
+
+  /**
+   * Run though the specified time period(s) and take Actions as if that time passed by right now, all at once. The
+   * Overlap Policy can be overridden for the scope of the Backfill.
+   */
+  backfill(options: Backfill | Backfill[]): Promise<void>;
+
+  /**
+   * Pause the Schedule
+   */
+  pause(note?: string): Promise<void>;
+
+  /**
+   * Unpause the Schedule
+   */
+  unpause(note?: string): Promise<void>;
+
+  /**
+   * Fetch the Schedule's description from the Server
+   */
+  describe(): Promise<ScheduleDescription>;
+
+  /**
+   * Get a handle to the most recent Action started
+   */
+  lastAction<T extends ScheduleActionType>(): Promise<HandleFor<T>>;
+
+  /**
+   * Readonly accessor to the underlying ScheduleClient
+   */
+  readonly client: ScheduleClient;
+}
+
+export type Base64 = string;
+
+export interface Schedule {
+  /**
+   * Schedule Id
+   *
+   * We recommend using a meaningful business identifier.
+   */
+  id: string;
+
+  /**
+   * Additional non-indexed information attached to the Schedule. The values can be anything that is
+   * serializable by the {@link DataConverter}.
+   */
+  memo?: Record<string, any>;
+
+  /**
+   * Additional indexed information attached to the Schedule. More info:
+   * https://docs.temporal.io/docs/typescript/search-attributes
+   *
+   * Values are always converted using {@link JsonPayloadConverter}, even when a custom Data Converter is provided.
+   */
+  searchAttributes: SearchAttributes;
+
+  // TODO flatten this?
+  info: ScheduleInfo;
+}
+
+/**
+ * The current Schedule details. They may not match the Schedule as created because:
+ * - some fields in the state are modified automatically
+ * - the schedule may have been modified by {@link ScheduleHandle.update} or
+ *   {@link ScheduleHandle.pause}/{@link ScheduleHandle.unpause}
+ */
+export interface ScheduleDescription {
+  /** When Actions should be taken */
+  spec: RequireAtLeastOne<ScheduleSpec, 'calendars' | 'intervals'>;
+
+  /**
+   * Which Action to take
+   */
+  action: ScheduleActionOptions;
+
+  /**
+   * Controls what happens when an Action would be started by a Schedule at the same time that an older Action is still
+   * running.
+   *
+   * @default {@link ScheduleOverlapPolicy.Skip}
+   */
+  overlap: ScheduleOverlapPolicy;
+
+  /**
+   * The Temporal Server might be down or unavailable at the time when a Schedule should take an Action. When the Server
+   * comes back up, `catchupWindow` controls which missed Actions should be taken at that point. The default is one
+   * minute, which means that the Schedule attempts to take any Actions that wouldn't be more than one minute late. It
+   * takes those Actions according to the {@link ScheduleOverlapPolicy}. An outage that lasts longer than the Catchup
+   * Window could lead to missed Actions. (But you can always {@link ScheduleHandle.backfill}.)
+   *
+   * @default 1 minute
+   */
+  catchupWindow: Milliseconds;
+
+  /**
+   * When an Action times out or reaches the end of its Retry Policy, {@link pause}.
+   *
+   * With {@link ScheduleOverlapPolicy.AllowAll}, this pause might not apply to the next Action, because the next Action
+   * might have already started previous to the failed one finishing. Pausing applies only to Actions that are scheduled
+   * to start after the failed one finishes.
+   *
+   * @default false
+   */
+  pauseOnFailure: boolean;
+
+  /**
+   * Informative human-readable message with contextual notes, e.g. the reason
+   * a Schedule is paused. The system may overwrite this message on certain
+   * conditions, e.g. when pause-on-failure happens.
+   */
+  note?: string;
+
+  /**
+   * Is currently paused.
+   *
+   * @default false
+   */
+  paused: boolean;
+
+  /** Whether the number of Actions to take is limited. */
+  actionsAreLimited: boolean;
+
+  /**
+   * Limit the number of Actions to take.
+   *
+   * This number is decremented after each Action is taken, and Actions are not
+   * taken when the number is `0` (unless {@link ScheduleHandle.trigger} is called).
+   *
+   * @default unlimited
+   */
+  remainingActions?: NonNegativeInteger;
+}
+
+export interface ScheduleListPage {
+  schedules: Schedule[];
+  nextPageToken?: Base64;
+
+  /**
+   * Token to use to when calling {@link ScheduleClient.listByPage}.
+   *
+   * If `undefined`, there are no more Schedules.
+   */
+  nextPageToken?: Base64;
+}
+
+export type WorkflowExecution = Required<temporal.api.common.v1.IWorkflowExecution>;
+
+export type ScheduleInfo = Schedule & {
+  /** Number of Actions taken so far. */
+  numActionsTaken: number;
+  // TODO or numberOfActionsTaken etc?
+
+  /** Number of times a scheduled Action was skipped due to missing the catchup window. */
+  numActionsMissedCatchupWindow: number;
+
+  /** Number of Actions skipped due to overlap. */
+  numActionsSkippedOverlap: number;
+
+  /**
+   * Currently-running workflows started by this schedule. (There might be
+   * more than one if the overlap policy allows overlaps.)
+   * Note that the run_ids in here are the original execution run ids as
+   * started by the schedule. If the workflows retried, did continue-as-new,
+   * or were reset, they might still be running but with a different run_id.
+   */
+  runningWorkflows: WorkflowExecution[];
+
+  /**
+   * Most recent 10 Actions started (including manual triggers).
+   *
+   * Sorted from older start time to newer.
+   */
+  recentActions: ScheduleAction[];
+
+  /** Next 10 scheduled Action times */
+  nextActionTimes: Date[];
+
+  createdAt: Date;
+  lastUpdatedAt: Date;
+
+  isValid(): boolean;
+
+  /** Error for invalid schedule. If this is present, no actions will be taken. */
+  invalidScheduleError?: string;
+};
+
+export interface ScheduleAction {
+  /** Time that the Action was scheduled for, including jitter. */
+  scheduledAt: Date;
+
+  /** Time that the Action was actually taken. */
+  takenAt: Date;
+
+  /** If action was {@link StartWorkflowAction}. */
+  workflow?: WorkflowExecution;
+  // TODO or WorkflowHandle? would be more convenient, eg `const latestResult = await recentActions.pop().result()`
+}
+
+export interface ScheduleClientOptions {
+  /**
+   * {@link DataConverter} to use for serializing and deserializing payloads
+   */
+  dataConverter?: DataConverter;
+
+  /**
+   * Used to override and extend default Connection functionality
+   *
+   * Useful for injecting auth headers and tracing Workflow executions
+   */
+  interceptors?: ScheduleClientInterceptors;
+
+  /**
+   * Identity to report to the server
+   *
+   * @default `${process.pid}@${os.hostname()}`
+   */
+  identity?: string;
+
+  /**
+   * Connection to use to communicate with the server.
+   *
+   * By default `ScheduleClient` connects to localhost.
+   *
+   * Connections are expensive to construct and should be reused.
+   */
+  connection?: ConnectionLike;
+
+  /**
+   * Server namespace
+   *
+   * @default default
+   */
+  namespace?: string;
+}
+
+export type ScheduleClientOptionsWithDefaults = Replace<
+  Required<ScheduleClientOptions>,
+  {
+    connection?: ConnectionLike;
+  }
+>;
+export type LoadedScheduleClientOptions = ScheduleClientOptionsWithDefaults & {
+  loadedDataConverter: LoadedDataConverter;
+};
+
+export function defaultScheduleClientOptions(): ScheduleClientOptionsWithDefaults {
+  return {
+    dataConverter: {},
+    // The equivalent in Java is ManagementFactory.getRuntimeMXBean().getName()
+    identity: `${process.pid}@${os.hostname()}`,
+    interceptors: {},
+    namespace: 'default',
+  };
+}
+
+// TODO
+// function ensureArgs<W extends Workflow, T extends ScheduleOptions<W>>(opts: T): Omit<T, 'args'> & { args: unknown[] } {
+//   const { args, ...rest } = opts;
+//   return { args: args ?? [], ...rest };
+// }
+
+interface SchdeduleHandleOptions extends GetSchdeduleHandleOptions {
+  workflowId: string;
+  runId?: string;
+  interceptors: ScheduleClientCallsInterceptor[];
+  /**
+   * A runId to use for getting the workflow's result.
+   *
+   * - When creating a handle using `getHandle`, uses the provided runId or firstExecutionRunId
+   * - When creating a handle using `start`, uses the returned runId (first in the chain)
+   * - When creating a handle using `signalWithStart`, uses the the returned runId
+   */
+  runIdForResult?: string;
+}
+
+/**
+ * Policy for overlapping Actions.
+ */
+export enum ScheduleOverlapPolicy {
+  /**
+   * Don't start a new Action.
+   */
+  Skip = 1,
+
+  /**
+   * Start another Action as soon as the current Action completes, but only buffer one Action in this way. If another
+   * Action is supposed to start, but one Action is running and one is already buffered, then only the buffered one will
+   * be started after the running Action finishes.
+   */
+  BufferOne,
+
+  /**
+   * Allows an unlimited number of Actions to buffer. They are started sequentially.
+   */
+  BufferAll,
+
+  /**
+   * Cancels the running Action, and then starts the new Action once the cancelled one completes.
+   */
+  CancelOther,
+
+  /**
+   * Terminate the running Action and start the new Action immediately.
+   */
+  TerminateOther,
+
+  /**
+   * Allow any number of Actions to start immediately.
+   *
+   * This is the only policy under which multiple Actions can run concurrently.
+   *
+   * {@link lastCompletionResult} and {@link lastFailure} will not be available.
+   */
+  AllowAll,
+}
+
+export interface Backfill {
+  start: Date;
+  end: Date;
+  /**
+   * Override overlap policy for this request.
+   */
+  overlap?: ScheduleOverlapPolicy;
+}
+
+/**
+ * The range of values depends on which, if any, fields are set:
+ *
+ * ```
+ * {} -> all values
+ * {start} -> start
+ * {start, end} -> every value from start to end (implies step = 1)
+ * {start, step} -> from start, by step (implies end is max for this field)
+ * {start, end, step} -> from start to end, by step
+ * {step} -> all values, by step (implies start and end are full range for this field)
+ * {end} and {end, step} are not allowed
+ * ```
+ * TODO is there a way to express not allowed ^ in type?
+ *
+ * For example:
+ *
+ * ```
+ * {start: 2, end: 10, step: 3} -> 2, 5, 8
+ * ```
+ */
+export interface Range<Unit> {
+  start?: Unit;
+  end?: Unit;
+
+  /**
+   * The step to take between each value.
+   *
+   * @default 1
+   */
+  step?: PositiveInteger;
+}
+
+export type AnyValue = '*';
+
+export type ZeroTo59 =
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17
+  | 18
+  | 19
+  | 20
+  | 21
+  | 22
+  | 23
+  | 24
+  | 25
+  | 26
+  | 27
+  | 28
+  | 29
+  | 30
+  | 31
+  | 32
+  | 33
+  | 34
+  | 35
+  | 36
+  | 37
+  | 38
+  | 39
+  | 40
+  | 41
+  | 42
+  | 43
+  | 44
+  | 45
+  | 46
+  | 47
+  | 48
+  | 49
+  | 50
+  | 51
+  | 52
+  | 53
+  | 54
+  | 55
+  | 56
+  | 57
+  | 58
+  | 59;
+
+export type Second = Range<ZeroTo59> | ZeroTo59;
+export type Minute = Range<ZeroTo59> | ZeroTo59;
+
+export type ZeroTo23 =
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17
+  | 18
+  | 19
+  | 20
+  | 21
+  | 22
+  | 23;
+
+export type Hour = Range<ZeroTo23> | ZeroTo23;
+
+export type ZeroTo30 =
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 13
+  | 14
+  | 15
+  | 16
+  | 17
+  | 18
+  | 19
+  | 20
+  | 21
+  | 22
+  | 23
+  | 24
+  | 25
+  | 26
+  | 27
+  | 28
+  | 29
+  | 30;
+
+export type DayOfMonth = Range<ZeroTo30> | ZeroTo30;
+
+export type ZeroTo11 = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
+
+export type MonthName =
+  | 'JAN'
+  | 'JANUARY'
+  | 'FEB'
+  | 'FEBRUARY'
+  | 'MAR'
+  | 'MARCH'
+  | 'APR'
+  | 'APRIL'
+  | 'MAY'
+  | 'JUN'
+  | 'JUNE'
+  | 'JUL'
+  | 'JULY'
+  | 'AUG'
+  | 'AUGUST'
+  | 'SEP'
+  | 'SEPTEMBER'
+  | 'OCT'
+  | 'OCTOBER'
+  | 'NOV'
+  | 'NOVEMBER'
+  | 'DEC'
+  | 'DECEMBER';
+
+export type MonthValue = ZeroTo11 | MonthName;
+
+export type Month = Range<MonthValue> | MonthValue;
+
+export type TwoThousandTo2100 =
+  | 2000
+  | 2001
+  | 2002
+  | 2003
+  | 2004
+  | 2005
+  | 2006
+  | 2007
+  | 2008
+  | 2009
+  | 2010
+  | 2011
+  | 2012
+  | 2013
+  | 2014
+  | 2015
+  | 2016
+  | 2017
+  | 2018
+  | 2019
+  | 2020
+  | 2021
+  | 2022
+  | 2023
+  | 2024
+  | 2025
+  | 2026
+  | 2027
+  | 2028
+  | 2029
+  | 2030
+  | 2031
+  | 2032
+  | 2033
+  | 2034
+  | 2035
+  | 2036
+  | 2037
+  | 2038
+  | 2039
+  | 2040
+  | 2041
+  | 2042
+  | 2043
+  | 2044
+  | 2045
+  | 2046
+  | 2047
+  | 2048
+  | 2049
+  | 2050
+  | 2051
+  | 2052
+  | 2053
+  | 2054
+  | 2055
+  | 2056
+  | 2057
+  | 2058
+  | 2059
+  | 2060
+  | 2061
+  | 2062
+  | 2063
+  | 2064
+  | 2065
+  | 2066
+  | 2067
+  | 2068
+  | 2069
+  | 2070
+  | 2071
+  | 2072
+  | 2073
+  | 2074
+  | 2075
+  | 2076
+  | 2077
+  | 2078
+  | 2079
+  | 2080
+  | 2081
+  | 2082
+  | 2083
+  | 2084
+  | 2085
+  | 2086
+  | 2087
+  | 2088
+  | 2089
+  | 2090
+  | 2091
+  | 2092
+  | 2093
+  | 2094
+  | 2095
+  | 2096
+  | 2097
+  | 2098
+  | 2099
+  | 2100;
+
+/**
+ * Temporal Server currently only supports specifying years in the range `[2000, 2100]`.
+ */
+export type Year = Range<TwoThousandTo2100> | TwoThousandTo2100;
+
+/**
+ * Both 0 and 7 mean Sunday
+ */
+export type ZeroTo7 = 0 | 1 | 2 | 3 | 4 | 5 | 7;
+
+export type DayOfWeekName =
+  | 'SU'
+  | 'SUN'
+  | 'SUNDAY'
+  | 'MO'
+  | 'MON'
+  | 'MONDAY'
+  | 'TU'
+  | 'TUE'
+  | 'TUES'
+  | 'TUESDAY'
+  | 'WE'
+  | 'WED'
+  | 'WEDNESDAY'
+  | 'TH'
+  | 'THU'
+  | 'THUR'
+  | 'THURS'
+  | 'THURSDAY'
+  | 'FR'
+  | 'FRI'
+  | 'FRIDAY'
+  | 'SA'
+  | 'SAT'
+  | 'SATURDAY';
+
+export type DayOfWeekValue = ZeroTo7 | DayOfWeekName;
+
+// TODO can we do something to make it case insensitive?
+// export type DayOfWeekValue<T> = ZeroTo7 | Uppercase<T> extends DayOfWeekName ? T : DayOfWeekName
+export type DayOfWeek = Range<DayOfWeekValue> | DayOfWeekValue;
+
+/**
+ * An event specification relative to the calendar, similar to a traditional cron specification.
+ *
+ * A second in time matches if all fields match. This includes `dayOfMonth` and `dayOfWeek`.
+ */
+export interface CalendarSpec {
+  /**
+   * @default 0
+   */
+  second?: Second | Second[];
+
+  /**
+   * @default 0
+   */
+  minute?: Minute | Minute[];
+
+  /**
+   * @default 0
+   */
+  hour?: Hour | Hour[];
+
+  /**
+   * @default {@link AnyValue}
+   */
+  dayOfMonth?: DayOfMonth | DayOfMonth[];
+
+  /**
+   * @default {@link AnyValue}
+   */
+  month?: Month | Month[];
+
+  /**
+   * @default {@link AnyValue}
+   */
+  year?: Year | Year[];
+
+  /**
+   * Can accept 0 or 7 as Sunday.
+   *
+   * @default {@link AnyValue}
+   */
+  dayOfWeek?: DayOfWeek | DayOfWeek[];
+}
+
+/**
+ * IntervalSpec matches times that can be expressed as:
+ *
+ * `Epoch + (n * every) + at`
+ *
+ * where `n` is any integer ≥ 0.
+ *
+ * For example, an `every` of 1 hour with `at` of zero would match every hour, on the hour. The same `every` but an `at`
+ * of 19 minutes would match every `xx:19:00`. An `every` of 28 days with `at` zero would match `2022-02-17T00:00:00Z`
+ * (among other times). The same `every` with `at` of 3 days, 5 hours, and 23 minutes would match `2022-02-20T05:23:00Z`
+ * instead.
+ */
+export interface IntervalSpec {
+  every: Seconds;
+
+  /**
+   * @default 0
+   */
+  at?: Seconds;
+}
+
+/**
+ * A complete description of a set of absolute timestamps (possibly infinite) that an Action should occur at. These times
+ * never change, except that the definition of a time zone can change over time (most commonly, when daylight saving
+ * time policy changes for an area). To create a totally self-contained `ScheduleSpec`, use UTC.
+ */
+export interface ScheduleSpec {
+  /** Calendar-based specifications of times. */
+  calendars?: CalendarSpec[];
+
+  /** Interval-based specifications of times. */
+  intervals?: IntervalSpec[];
+
+  /** Any timestamps matching any of the exclude_calendar specs will be skipped. */
+  skip?: CalendarSpec[];
+
+  /**
+   * Any timestamps before `startAt` will be skipped. Together, `startAt` and `endAt` make an inclusive interval.
+   *
+   * @default The beginning of time
+   */
+  startAt?: Date;
+
+  /**
+   * Any timestamps after `endAt` will be skipped.
+   *
+   * @default The end of time
+   */
+  endAt?: Date;
+
+  /**
+   * All timestamps will be incremented by a random value from 0 to this amount of jitter.
+   *
+   * @default 1 second
+   */
+  jitter?: Milliseconds;
+
+  // Add to SDK if requested by users:
+  //
+  // string timezone_name = 10;
+  // bytes timezone_data = 11;
+  //
+  // Time zone to interpret all CalendarSpecs in.
+  //
+  // If unset, defaults to UTC. We recommend using UTC for your application if
+  // at all possible, to avoid various surprising properties of time zones.
+  //
+  // Time zones may be provided by name, corresponding to names in the IANA
+  // time zone database (see https://www.iana.org/time-zones). The definition
+  // will be loaded by the Temporal server from the environment it runs in.
+  //
+  // If your application requires more control over the time zone definition
+  // used, it may pass in a complete definition in the form of a TZif file
+  // from the time zone database. If present, this will be used instead of
+  // loading anything from the environment. You are then responsible for
+  // updating timezone_data when the definition changes.
+  //
+  // Calendar spec matching is based on literal matching of the clock time
+  // with no special handling of DST: if you write a calendar spec that fires
+  // at 2:30am and specify a time zone that follows DST, that action will not
+  // be triggered on the day that has no 2:30am. Similarly, an action that
+  // fires at 1:30am will be triggered twice on the day that has two 1:30s.
+}
+
+export type StartWorkflowAction<Action extends Workflow> = Omit<
+  WorkflowStartOptions<Action>,
+  'workflowIdReusePolicy' | 'cronSchedule' | 'followRuns'
+> & {
+  /**
+   * Metadata that's propagated between workflows and activities? TODO someone explain headers to me so I can improve
+   * this apidoc and maybe:
+   * - remove from here and only expose to interceptor?
+   * - or make it Record<string, unknown> and apply client's data converter?
+   */
+  headers: Headers;
+};
+
+export type ScheduleActionType = Workflow;
+
+/**
+ * Currently, Temporal Server only supports {@link StartWorkflowAction}.
+ */
+export type ScheduleActionOptions<Action extends ScheduleActionType = ScheduleActionType> = StartWorkflowAction<Action>;
+// in future:
+// type SomethingElse = 'hi'
+// type ScheduleAction = Workflow | SomethingElse
+// type ExpectsSomethingElse<Action extends SomethingElse> = Action extends SomethingElse ? Action : number;
+// type StartSomethingElseAction<Action extends SomethingElse> = ExpectsSomethingElse<Action>
+// type ScheduleActionOptions<Action extends ScheduleAction> = Action extends Workflow
+//   ? StartWorkflowAction<Action>
+//   : Action extends SomethingElse
+//     ? StartSomethingElseAction<Action>
+//     : never;
+
+export type HandleFor<T> = T extends Workflow ? WorkflowHandle<T> : never;
+
+/**
+ * Options for starting a Workflow
+ */
+export interface ScheduleOptions<Action extends ScheduleActionType> {
+  /**
+   * Schedule Id
+   *
+   * We recommend using a meaningful business identifier.
+   */
+  id: string;
+
+  /** When Actions should be taken */
+  spec: RequireAtLeastOne<ScheduleSpec, 'calendars' | 'intervals'>;
+
+  /**
+   * Which Action to take
+   */
+  action: ScheduleActionOptions<Action>;
+
+  /**
+   * Controls what happens when an Action would be started by a Schedule at the same time that an older Action is still
+   * running.
+   *
+   * @default {@link ScheduleOverlapPolicy.Skip}
+   */
+  overlap?: ScheduleOverlapPolicy;
+
+  /**
+   * The Temporal Server might be down or unavailable at the time when a Schedule should take an Action. When the Server
+   * comes back up, `catchupWindow` controls which missed Actions should be taken at that point. The default is one
+   * minute, which means that the Schedule attempts to take any Actions that wouldn't be more than one minute late. It
+   * takes those Actions according to the {@link ScheduleOverlapPolicy}. An outage that lasts longer than the Catchup
+   * Window could lead to missed Actions. (But you can always {@link ScheduleHandle.backfill}.)
+   *
+   * @default 1 minute
+   */
+  catchupWindow?: Milliseconds;
+
+  /**
+   * When an Action times out or reaches the end of its Retry Policy, {@link pause}.
+   *
+   * With {@link ScheduleOverlapPolicy.AllowAll}, this pause might not apply to the next Action, because the next Action
+   * might have already started previous to the failed one finishing. Pausing applies only to Actions that are scheduled
+   * to start after the failed one finishes.
+   *
+   * @default false
+   */
+  pauseOnFailure?: boolean;
+
+  /**
+   * Informative human-readable message with contextual notes, e.g. the reason
+   * a Schedule is paused. The system may overwrite this message on certain
+   * conditions, e.g. when pause-on-failure happens.
+   */
+  note?: string;
+
+  /**
+   * Start in paused state.
+   *
+   * @default false
+   */
+  pause?: boolean;
+
+  /**
+   * Limit the number of Actions to take.
+   *
+   * This number is decremented after each Action is taken, and Actions are not
+   * taken when the number is `0` (unless {@link ScheduleHandle.trigger} is called).
+   *
+   * @default unlimited
+   */
+  remainingActions?: NonNegativeInteger;
+
+  /**
+   * Trigger one Action immediately.
+   *
+   * @default false
+   */
+  triggerImmediately?: boolean;
+
+  /**
+   * Runs though the specified time periods and takes Actions as if that time passed by right now, all at once. The
+   * overlap policy can be overridden for the scope of the backfill.
+   */
+  backfill?: Backfill[];
+
+  /**
+   * Additional non-indexed information attached to the Schedule. The values can be anything that is
+   * serializable by the {@link DataConverter}.
+   */
+  memo?: Record<string, any>;
+
+  /**
+   * Additional indexed information attached to the Schedule. More info:
+   * https://docs.temporal.io/docs/typescript/search-attributes
+   *
+   * Values are always converted using {@link JsonPayloadConverter}, even when a custom Data Converter is provided.
+   */
+  searchAttributes?: SearchAttributes;
+}
+
+export interface ListScheduleOptions {
+  /**
+   * How many results to return
+   * @default 1000
+   */
+  pageSize?: number;
+
+  /** Token to get the next page of results */
+  nextPageToken?: Base64;
+}
+
+/**
+ * Client for starting Workflow executions and creating Workflow handles
+ */
+export class ScheduleClient {
+  public readonly options: LoadedScheduleClientOptions;
+  public readonly connection: ConnectionLike;
+
+  constructor(options?: ScheduleClientOptions) {
+    this.connection = options?.connection ?? Connection.lazy();
+    this.options = {
+      ...defaultScheduleClientOptions(),
+      ...options,
+      loadedDataConverter: loadDataConverter(options?.dataConverter),
+    };
+  }
+
+  /**
+   * Raw gRPC access to the Temporal service. Schedule-related methods are included in {@link WorkflowService}.
+   *
+   * **NOTE**: The namespace provided in {@link options} is **not** automatically set on requests made to the service.
+   */
+  get scheduleService(): WorkflowService {
+    return this.connection.workflowService;
+  }
+
+  /**
+   * Set the deadline for any service requests executed in `fn`'s scope.
+   */
+  async withDeadline<R>(deadline: number | Date, fn: () => Promise<R>): Promise<R> {
+    return await this.connection.withDeadline(deadline, fn);
+  }
+
+  /**
+   * Set metadata for any service requests executed in `fn`'s scope.
+   *
+   * @returns returned value of `fn`
+   *
+   * @see {@link Connection.withMetadata}
+   */
+  async withMetadata<R>(metadata: Metadata, fn: () => Promise<R>): Promise<R> {
+    return await this.connection.withMetadata(metadata, fn);
+  }
+
+  /**
+   * Create a new Schedule.
+   */
+  public async create<Action extends ScheduleActionType>(options: ScheduleOptions<Action>): Promise<ScheduleHandle> {  }
+
+  /**
+   * List Schedules with an `AsyncIterator`:
+   *
+   * ```ts
+   * for await (const schedule: Schedule of client.list()) {
+   *   const { id, memo, searchAttributes } = schedule
+   *   // ...
+   * }
+   * ```
+   */
+  public list(options?: ListScheduleOptions): AsyncIterator<Schedule> {}
+
+  /** List Schedules, one page at a time */
+  public async listByPage(options?: ListScheduleOptions): Promise<ScheduleListPage> {}
+
+  /**
+   * Get a handle to a Schedule
+   *
+   * This method does not validate `scheduleId`. If there is no Schedule with the given `scheduleId`, handle
+   * methods like `handle.describe()` will throw a {@link ScheduleNotFoundError} error.
+   */
+  public getHandle(scheduleId: string): ScheduleHandle {  }
+}
 ```
 
 ### Higher-level client

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -530,17 +530,17 @@ export interface Range<Unit> {
 }
 
 export type NumberRange = Range<number> | number
-export type NumberSpec = NumberRange | NumberRange[] | string;
+export type NumberSpec = NumberRange | NumberRange[] | '*';
 export type NumberSpecDescription = Range<number>[];
 
 export type Month = 'JANUARY' | 'FEBRUARY' | 'MARCH' | 'APRIL' | 'MAY' | 'JUNE' | 'JULY' | 'AUGUST' | 'SEPTEMBER' | 'OCTOBER' | 'NOVEMBER' | 'DECEMBER';
 export type MonthRange = Range<Month> | Month;
-export type MonthSpec = MonthRange | MonthRange[] | string;
+export type MonthSpec = MonthRange | MonthRange[] | '*';
 export type MonthSpecDescription = Range<Month>[];
 
 export type Day = 'SUNDAY' | 'MONDAY' | 'TUESDAY' | 'WEDNESDAY' | 'THURSDAY' | 'FRIDAY' | 'SATURDAY';
 export type DayRange = Range<Day> | Day;
-export type DaySpec = DayRange | DayRange[] | string;
+export type DaySpec = DayRange | DayRange[] | '*';
 export type DaySpecDescription = Range<Day>[];
 
 /**
@@ -593,6 +593,11 @@ export interface CalendarSpec {
    * @default '*'
    */
   dayOfWeek?: DaySpec;
+
+  /**
+   * Description of the intention of this spec.
+   */
+  comment?: string;
 }
 
 /**
@@ -643,6 +648,11 @@ export interface CalendarSpecDescription {
    * @default `[{ start: 'SUNDAY', end: 'SATURDAY' }]`
    */
   dayOfWeek?: DaySpecDescription;
+
+  /**
+   * Description of the intention of this spec.
+   */
+  comment?: string;
 }
 
 /**
@@ -708,7 +718,8 @@ export interface ScheduleSpec {
   intervals?: IntervalSpec[];
 
   /**
-   * [Cron expressions](https://crontab.guru/)
+   * [Cron expressions](https://crontab.guru/). This is provided for easy migration from legacy Cron Workflows. For new
+   * use cases, we recommend using {@link calendars} or {@link intervals} for readability and maintainability.
    *
    * For example, `0 12 * * MON-WED,FRI` is every M/Tu/W/F at noon, and is equivalent to this {@link CalendarSpec}:
    *
@@ -1134,24 +1145,3 @@ export interface ScheduleClientInterceptors {
   calls?: ScheduleClientCallsInterceptorFactory[]
 }
 ```
-
-- cron_string holds a traditional cron specification as a string. It
-- accepts 5, 6, or 7 fields, separated by spaces, and interprets them the
-- same way as CalendarSpec.
-- 5 fields: minute, hour, day_of_month, month, day_of_week
-- 6 fields: minute, hour, day_of_month, month, day_of_week, year
-- 7 fields: second, minute, hour, day_of_month, month, day_of_week, year
-- If year is not given, it defaults to \*. If second is not given, it
-- defaults to 0.
-- Shorthands @yearly, @monthly, @weekly, @daily, and @hourly are also
-- accepted instead of the 5-7 time fields.
-- Optionally, the string can be preceded by CRON_TZ=<timezone name> or
-- TZ=<timezone name>, which will get copied to timezone_name. (There must
-- not also be a timezone_name present.)
-- Optionally "#" followed by a comment can appear at the end of the string.
-- Note that the special case that some cron implementations have for
-- treating day_of_month and day_of_week as "or" instead of "and" when both
-- are set is not implemented.
-- @every <interval>[/<phase>] is accepted and gets compiled into an
-- IntervalSpec instead. <interval> and <phase> should be a decimal integer
-- with a unit suffix s, m, h, or d.

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -9,15 +9,12 @@
 
 ## TS API
 
-Usage:
-
 ```ts
+import { ScheduleClient, ScheduleOverlapPolicy } from '@temporalio/client'
+import { addWeeks } from 'date-fns'
+import { myWorkflow } from './workflows'
+
 const client = new ScheduleClient()
-// or for languages with higher level clients:
-// client = new TemporalClient()
-// client.schedule.create()
-// or
-// client.createSchedule()
 
 const schedule = await client.create({
   id: 'biz-id',
@@ -37,7 +34,7 @@ const schedule = await client.create({
       hour: 23,
       minute: 5,
     },
-    endAt: addWeeks(new Date(), 4),
+    endAt: addWeeks(new Date(), 4), 
     jitter: '30s',
     timezone: 'US/Eastern',
   },
@@ -99,10 +96,15 @@ const { schedules, nextPageToken } = await client.list({
 })
 ```
 
-Types:
+### Higher-level client
 
 ```ts
-interface ScheduleHandle {
-  id: string
-}
+import { Client } from '@temporalio/client'
+
+const client = new Client()
+
+client.schedule.create()
+client.workflow.start() 
+client.asyncCompletion.heartbeat()
+client.operator.addSearchAttributes()
 ```

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -1,0 +1,108 @@
+# Schedules
+
+- [Docs](https://docs.temporal.io/workflows/#schedules)
+- gRPC API:
+  - [methods](https://github.com/temporalio/api/blob/799926c86eb13d8a9717d3561ab9b0df43796c06/temporal/api/workflowservice/v1/service.proto#L328-L370)
+  - [`request_response.proto`](https://github.com/temporalio/api/blob/799926c86eb13d8a9717d3561ab9b0df43796c06/temporal/api/workflowservice/v1/request_response.proto#L821-L957)
+  - [`schedule/v1/message.proto`](https://github.com/temporalio/api/blob/master/temporal/api/schedule/v1/message.proto)
+  - [`ScheduleOverlapPolicy` enum](https://github.com/temporalio/api/blob/master/temporal/api/enums/v1/schedule.proto)
+
+## TS API
+
+Usage:
+
+```ts
+const client = new ScheduleClient()
+// or for languages with higher level clients:
+// client = new TemporalClient()
+// client.schedule.create()
+// or
+// client.createSchedule()
+
+const schedule = await client.create({
+  id: 'biz-id',
+  spec: {
+    // every hour at minute 5
+    interval: {
+      every: '1h',
+      at: '5m',
+    },
+    // every 20 days since epoch at day 2
+    // interval: {
+    //   every: '20d',
+    //   at: '2d'
+    // }
+    exclude: {
+      // skip 11:05 pm
+      hour: 23,
+      minute: 5,
+    },
+    endAt: addWeeks(new Date(), 4),
+    jitter: '30s',
+    timezone: 'US/Eastern',
+  },
+  action: {
+    startWorkflow: {
+      workflowId: 'biz-id',
+      type: myWorkflow,
+      input: ['sorry this is the only thing reused, chad 😄'],
+    },
+  },
+  policies: {
+    overlap: ScheduleOverlapPolicy.BUFFER_ONE,
+    catchupWindow: '2m',
+    pauseOnFailure: true,
+  },
+  state: {
+    note: 'started schedule',
+    paused: true,
+    limitedActions: 10,
+  },
+  patch: {
+    triggerImmediately: true,
+    backfill: [
+      {
+        start: new Date(),
+        end: new Date(),
+        overlap: ScheduleOverlapPolicy.ALLOW_ALL,
+      },
+    ],
+    pause: true, // redundant with state.paused above (can use either)
+  },
+  memo,
+  searchAttributes,
+})
+
+const scheduleDescription = await schedule.describe()
+
+await schedule.listMatchingTimes({ start: new Date(), end: new Date() })
+
+await schedule.update({
+  spec,
+  action,
+  policies,
+  state,
+  conflictToken: scheduleDescription.conflictToken,
+})
+
+await schedule.patch({
+  triggerImmediately: true,
+  backfill,
+  unpause: true,
+})
+
+await schedule.delete()
+
+const { schedules, nextPageToken } = await client.list({
+  pageSize: 50,
+  nextPageToken: 'base64',
+})
+```
+
+Types:
+
+```ts
+interface ScheduleHandle {
+  id: string
+}
+```

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -101,10 +101,57 @@ const { schedules, nextPageToken } = await client.list({
 ```ts
 import { Client } from '@temporalio/client'
 
-const client = new Client()
+const client = new Client(options)
 
 client.schedule.create()
 client.workflow.start() 
 client.asyncCompletion.heartbeat()
 client.operator.addSearchAttributes()
+
+interface ClientOptions {
+  dataConverter?: DataConverter;
+  interceptors?: {
+    workflow: WorkflowClientInterceptors,
+    schedule: ScheduleClientInterceptors,
+  };
+  identity?: string;
+  connection?: ConnectionLike;
+  namespace?: string;
+  queryRejectCondition?: temporal.api.enums.v1.QueryRejectCondition;
+}
+```
+
+### Interceptors
+
+```ts
+interface ScheduleClientCallsInterceptor {
+  /**
+   * Intercept a service call to CreateSchedule
+   */
+  create?: (input: ScheduleStartInput, next: Next<this, 'create'>) => Promise<string /* conflictToken */>;
+  describe
+  listMatchingTimes
+  update
+  patch
+  delete
+  list
+}
+
+interface ScheduleClientCallsInterceptorFactoryInput {
+  id: string;
+}
+
+/**
+ * A function that takes a {@link ScheduleClientCallsInterceptorFactoryInput} and returns an interceptor
+ */
+export interface ScheduleClientCallsInterceptorFactory {
+  (input: ScheduleClientCallsInterceptorFactoryInput): ScheduleClientCallsInterceptor;
+}
+
+/**
+ * A mapping of interceptor type of a list of factory functions
+ */
+export interface ScheduleClientInterceptors {
+  calls?: ScheduleClientCallsInterceptorFactory[];
+}
 ```

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -635,7 +635,7 @@ export interface CalendarSpecDescription {
   /**
    * Use full years, like `2030`
    *
-   * @default `[{ start: 2000, step: 1 }]`
+   * @default `undefined` (meaning any year)
    */
   year?: NumberSpecDescription;
 

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -81,7 +81,7 @@ const scheduleDescription = await schedule.describe();
 
 const sameSchedule = client.getHandle('schedule-biz-id');
 
-const newSimilarSchedule = await client.create(scheduleDescription.copyOptions({ 
+const newSimilarSchedule = await client.create(scheduleDescription.copyOptions({
   id: 'new-id',
   action: {
     workflowId: 'wf-biz-id-2',
@@ -120,7 +120,7 @@ for await (const schedule: Schedule of client.list()) {
 
 ### Types
 
-```ts
+````ts
 import { DataConverter, LoadedDataConverter } from '@temporalio/common';
 import { loadDataConverter } from '@temporalio/internal-non-workflow-common';
 import {
@@ -141,9 +141,9 @@ import { WorkflowHandle, WorkflowStartOptions } from './workflow-client';
 export interface UpdateScheduleOptions {
   /**
    * How many times to retry the update.
-   * 
+   *
    * Set to `1` if you don't want to retry.
-   * 
+   *
    * @default 3
    */
   maximumAttempts?: number;
@@ -160,12 +160,12 @@ export interface ScheduleHandle {
 
   /**
    * Update the Schedule
-   * 
-   * This function calls `.describe()` and then tries to send the update to the Server. If the Schedule has changed 
-   * between the time of `.describe()` and the update, the Server throws an error, and the SDK retries, up to 
+   *
+   * This function calls `.describe()` and then tries to send the update to the Server. If the Schedule has changed
+   * between the time of `.describe()` and the update, the Server throws an error, and the SDK retries, up to
    * {@link UpdateScheduleOptions.maximumAttempts}.
-   * 
-   * If, inside `updateFn`, you no longer want the SDK to try sending the update to the Server, return undefined. 
+   *
+   * If, inside `updateFn`, you no longer want the SDK to try sending the update to the Server, return undefined.
    */
   update(updateFn: (schedule: Schedule) => Schedule | undefined, options?: UpdateScheduleOptions): Promise<void>;
 
@@ -176,7 +176,7 @@ export interface ScheduleHandle {
 
   /**
    * Trigger an Action to be taken immediately
-   * 
+   *
    * @param overlap Override the Overlap Policy for this one trigger. Defaults to {@link ScheduleOverlapPolicy.ALLOW_ALL}.
    */
   trigger(overlap?: ScheduleOverlapPolicy;): Promise<void>;
@@ -189,7 +189,7 @@ export interface ScheduleHandle {
 
   /**
    * Pause the Schedule
-   * 
+   *
    * @param note A new {@link Schedule.note}. Defaults to `"Paused via TypeScript SDK"`
    * @throws {@link ValueError} if empty string is passed
    */
@@ -197,7 +197,7 @@ export interface ScheduleHandle {
 
   /**
    * Unpause the Schedule
-   * 
+   *
    * @param note A new {@link Schedule.note}. Defaults to `"Unpaused via TypeScript SDK"`
    * @throws {@link ValueError} if empty string is passed
    */
@@ -251,7 +251,7 @@ export interface ListScheduleEntry {
 
   /**
    * Whether Schedule is currently paused.
-   * 
+   *
    * @default false
    */
   paused: boolean;
@@ -316,9 +316,9 @@ export type Schedule = ListScheduleEntry & {
   pauseOnFailure: boolean;
 
   /**
-   * The Actions remaining in this Schedule. Once this number hits `0`, no further Actions are taken (unless {@link 
+   * The Actions remaining in this Schedule. Once this number hits `0`, no further Actions are taken (unless {@link
    * ScheduleHandle.trigger} is called).
-   * 
+   *
    * @default undefined (unlimited)
    */
   remainingActions?: number;
@@ -349,8 +349,8 @@ export type Schedule = ListScheduleEntry & {
 }
 
 /**
- * Make all properties optional. 
- * 
+ * Make all properties optional.
+ *
  * If original Schedule is deleted, okay to use same `id`.
  */
 export type ScheduleOptionsOverrides<Action> = Partial<ScheduleOptions<Action>>
@@ -360,7 +360,7 @@ export interface WorkflowExecutionWithFirstExecutionRunId {
   workflowId: string;
 
   /**
-   * The Run Id of the original execution that was started by the Schedule. If the Workflow retried, did 
+   * The Run Id of the original execution that was started by the Schedule. If the Workflow retried, did
    * Continue-As-New, or was Reset, the following runs would have different Run Ids.
    */
   firstExecutionRunId: string;
@@ -440,11 +440,11 @@ export function defaultScheduleClientOptions(): ScheduleClientOptionsWithDefault
 export enum ScheduleOverlapPolicy {
   /**
    * Use server default (currently SKIP).
-   * 
+   *
    * TODO remove this field if this issue is implemented: https://github.com/temporalio/temporal/issues/3240
    */
   UNSPECIFIED = 0,
-  
+
   /**
    * Don't start a new Action.
    */
@@ -551,28 +551,28 @@ export type DaySpecDescription = Range<Day>[];
 export interface CalendarSpec {
   /**
    * Valid values: 0–59
-   * 
+   *
    * @default 0
    */
   second?: NumberSpec;
 
   /**
    * Valid values: 0–59
-   * 
+   *
    * @default 0
    */
   minute?: NumberSpec;
 
   /**
    * Valid values: 0–59
-   * 
+   *
    * @default 0
    */
   hour?: NumberSpec;
 
   /**
    * Valid values: 1–31
-   * 
+   *
    * @default '*'
    */
   dayOfMonth?: NumberSpec;
@@ -584,7 +584,7 @@ export interface CalendarSpec {
 
   /**
    * Use full years, like `2030`
-   * 
+   *
    * @default '*'
    */
   year?: NumberSpec;
@@ -601,28 +601,28 @@ export interface CalendarSpec {
 export interface CalendarSpecDescription {
   /**
    * Valid values: 0–59
-   * 
+   *
    * @default `[{ start: 0 }]`
    */
   second?: NumberSpecDescription;
 
   /**
    * Valid values: 0–59
-   * 
+   *
    * @default `[{ start: 0 }]`
    */
   minute?: NumberSpecDescription;
 
   /**
    * Valid values: 0–59
-   * 
+   *
    * @default `[{ start: 0 }]`
    */
   hour?: NumberSpecDescription;
 
   /**
    * Valid values: 1–31
-   * 
+   *
    * @default `[{ start: 1, end: 31 }]`
    */
   dayOfMonth?: NumberSpecDescription;
@@ -634,7 +634,7 @@ export interface CalendarSpecDescription {
 
   /**
    * Use full years, like `2030`
-   * 
+   *
    * @default `[{ start: 2000, step: 1 }]`
    */
   year?: NumberSpecDescription;
@@ -660,14 +660,14 @@ export interface CalendarSpecDescription {
 export interface IntervalSpec {
   /**
    * Value is rounded to the nearest second.
-   * 
+   *
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
   every: number | string;
 
   /**
    * Value is rounded to the nearest second.
-   * 
+   *
    * @default 0
    * @format number of milliseconds or {@link https://www.npmjs.com/package/ms | ms-formatted string}
    */
@@ -680,14 +680,14 @@ export interface IntervalSpec {
 export interface IntervalSpecDescription {
   /**
    * Value is rounded to the nearest second.
-   * 
+   *
    * @format number of milliseconds
    */
   every: number;
 
   /**
    * Value is rounded to the nearest second.
-   * 
+   *
    * @default 0
    * @format number of milliseconds
    */
@@ -708,9 +708,9 @@ export interface ScheduleSpec {
 
   /**
    * [Cron expressions](https://crontab.guru/)
-   * 
+   *
    * For example, `0 12 * * MON-WED,FRI` is every M/Tu/W/F at noon, and is equivalent to this {@link CalendarSpec}:
-   * 
+   *
    * ```ts
    * {
    *   hour: 12,
@@ -720,12 +720,12 @@ export interface ScheduleSpec {
    *   }, 'FRIDAY']
    * }
    * ```
-   */ 
+   */
   cronExpressions?: string[];
 
-  /** 
-   * Any matching times will be skipped. 
-   * 
+  /**
+   * Any matching times will be skipped.
+   *
    * All aspects of the CalendarSpec—including seconds—must match a time for the time to be skipped.
    */
   skip?: CalendarSpec[];
@@ -756,11 +756,11 @@ export interface ScheduleSpec {
 
   /**
    * IANA timezone name, for example `US/Pacific`.
-   * 
+   *
    * https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-   * 
+   *
    * The definition will be loaded by Temporal Server from the environment it runs in.
-   * 
+   *
    * Calendar spec matching is based on literal matching of the clock time
    * with no special handling of DST: if you write a calendar spec that fires
    * at 2:30am and specify a time zone that follows DST, that action will not
@@ -768,7 +768,7 @@ export interface ScheduleSpec {
    * fires at 1:30am will be triggered twice on the day that has two 1:30s.
    *
    * Also note that no actions are taken on leap-seconds (e.g. 23:59:60 UTC).
-   * 
+   *
    * @default UTC
    */
   timezone?: string;
@@ -847,7 +847,7 @@ export type ScheduleActionOptions<Action extends ScheduleActionType = ScheduleAc
 // type ScheduleActionType = Workflow | SomethingElse
 // type ExpectsSomethingElse<Action extends SomethingElse> = Action extends SomethingElse ? Action : number;
 // type StartSomethingElseAction<Action extends SomethingElse> = ExpectsSomethingElse<Action>
-// type ScheduleActionOptions<Action extends ScheduleActionType> = 
+// type ScheduleActionOptions<Action extends ScheduleActionType> =
 //   StartWorkflowAction<Action> | StartSomethingElseAction<Action>
 
 export type HandleFor<T> = T extends Workflow ? WorkflowHandle<T> : never;
@@ -873,7 +873,7 @@ export interface ScheduleOptions<Action extends ScheduleActionType> {
 
   /**
    * Controls what happens when an Action would be started by a Schedule at the same time that an older Action is still
-   * running. This can be changed after a Schedule has taken some Actions, and some changes might produce 
+   * running. This can be changed after a Schedule has taken some Actions, and some changes might produce
    * unintuitive results. In general, the later policy overrides the earlier policy.
    *
    * @default {@link ScheduleOverlapPolicy.SKIP}
@@ -967,7 +967,7 @@ export interface ListScheduleOptions {
  * Thrown from {@link ScheduleClient.create} if there's a running (not deleted) Schedule with the given `id`.
  */
 export class ScheduleAlreadyRunning extends Error {
-  public readonly name: string = 'ScheduleAlreadyRunning';  
+  public readonly name: string = 'ScheduleAlreadyRunning';
 
   constructor(message: string, public readonly scheduleId: string) {
     super(message);
@@ -1019,7 +1019,7 @@ export class ScheduleClient {
 
   /**
    * Create a new Schedule.
-   * 
+   *
    * @throws {@link ScheduleAlreadyRunning} if there's a running (not deleted) Schedule with the given `id`
    */
   public async create<Action extends ScheduleActionType>(options: ScheduleOptions<Action>): Promise<ScheduleHandle> {  }
@@ -1033,9 +1033,9 @@ export class ScheduleClient {
    *   // ...
    * }
    * ```
-   * 
+   *
    * To list one page at a time, instead use the raw gRPC method {@link WorkflowService.listSchedules}:
-   * 
+   *
    * ```ts
    * await { schedules, nextPageToken } = client.scheduleService.listSchedules()
    * ```
@@ -1050,7 +1050,7 @@ export class ScheduleClient {
    */
   public getHandle(scheduleId: string): ScheduleHandle {  }
 }
-```
+````
 
 ### Higher-level TS client
 
@@ -1060,20 +1060,20 @@ import { Client } from '@temporalio/client'
 const client = new Client(options)
 
 client.schedule.create()
-client.workflow.start() 
+client.workflow.start()
 client.asyncCompletion.heartbeat()
 client.operator.addSearchAttributes()
 
 interface ClientOptions {
-  dataConverter?: DataConverter;
+  dataConverter?: DataConverter
   interceptors?: {
-    workflow: WorkflowClientInterceptors,
-    schedule: ScheduleClientInterceptors,
-  };
-  identity?: string;
-  connection?: ConnectionLike;
-  namespace?: string;
-  queryRejectCondition?: temporal.api.enums.v1.QueryRejectCondition;
+    workflow: WorkflowClientInterceptors
+    schedule: ScheduleClientInterceptors
+  }
+  identity?: string
+  connection?: ConnectionLike
+  namespace?: string
+  queryRejectCondition?: temporal.api.enums.v1.QueryRejectCondition
 }
 ```
 
@@ -1084,24 +1084,29 @@ interface ScheduleClientCallsInterceptor {
   /**
    * Intercept a service call to CreateSchedule
    */
-  create?: (input: ScheduleStartInput, next: Next<this, 'create'>) => Promise<string /* conflictToken */>;
+  create?: (
+    input: ScheduleStartInput,
+    next: Next<this, 'create'>
+  ) => Promise<string /* conflictToken */>
 }
 
 interface ScheduleClientCallsInterceptorFactoryInput {
-  id: string;
+  id: string
 }
 
 /**
  * A function that takes a {@link ScheduleClientCallsInterceptorFactoryInput} and returns an interceptor
  */
 export interface ScheduleClientCallsInterceptorFactory {
-  (input: ScheduleClientCallsInterceptorFactoryInput): ScheduleClientCallsInterceptor;
+  (
+    input: ScheduleClientCallsInterceptorFactoryInput
+  ): ScheduleClientCallsInterceptor
 }
 
 /**
  * A mapping of interceptor type of a list of factory functions
  */
 export interface ScheduleClientInterceptors {
-  calls?: ScheduleClientCallsInterceptorFactory[];
+  calls?: ScheduleClientCallsInterceptorFactory[]
 }
 ```

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -635,12 +635,12 @@ export interface CalendarSpecDescription {
   /**
    * Use full years, like `2030`
    * 
-   * @default All possible values
+   * @default `[{ start: 2000, step: 1 }]`
    */
   year?: NumberSpecDescription;
 
   /**
-   * @default `[{ start: 'SUNDAY' , end: 'SATURDAY' }]`
+   * @default `[{ start: 'SUNDAY', end: 'SATURDAY' }]`
    */
   dayOfWeek?: DaySpecDescription;
 }
@@ -723,8 +723,14 @@ export interface ScheduleSpec {
    */ 
   cronExpressions?: string[];
 
-  /** Any matching times will be skipped. */
+  /** 
+   * Any matching times will be skipped. 
+   * 
+   * All aspects of the CalendarSpec—including seconds—must match a time for the time to be skipped.
+   */
   skip?: CalendarSpec[];
+  // TODO see if users want to be able to skip an IntervalSpec
+  // https://github.com/temporalio/api/pull/230/files#r956434347
 
   /**
    * Any times before `startAt` will be skipped. Together, `startAt` and `endAt` make an inclusive interval.

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -498,27 +498,25 @@ export interface Backfill {
 }
 
 /**
- * The range of values depends on which, if any, fields are set:
+ * Example Ranges:
  *
  * ```
- * {} -> all values
- * {start} -> start
- * {start, end} -> every value from start to end (implies step = 1)
- * {start, step} -> from start, by step (implies end is max for this field)
- * {start, end, step} -> from start to end, by step
- * {step} -> all values, by step (implies start and end are full range for this field)
- * {end} and {end, step} are not allowed
- * TODO is there a way to express not allowed ^ in type?
- * ```
- *
- * For example:
- *
- * ```
- * {start: 2, end: 10, step: 3} -> 2, 5, 8
+ * { start: 2 } ➡️ 2
+ * { start: 2, end: 4 } ➡️ 2, 3, 4
+ * { start: 2, end: 10, step: 3 } ➡️ 2, 5, 8
  * ```
  */
 export interface Range<Unit> {
-  start?: Unit;
+  /**
+   * Start of range (inclusive)
+   */
+  start: Unit;
+
+  /**
+   * End of range (inclusive)
+   *
+   * @default `start`
+   */
   end?: Unit;
 
   /**
@@ -601,7 +599,8 @@ export interface CalendarSpec {
 }
 
 /**
- * The version of {@link CalendarSpec} that you get back from {@link ScheduleHandle.describe}
+ * The version of {@link CalendarSpec} that you get back from {@link ScheduleHandle.describe} and 
+ * {@link ScheduleClient.list}
  */
 export interface CalendarSpecDescription {
   /**
@@ -861,14 +860,6 @@ export type StartWorkflowAction<Action extends Workflow> = Omit<
   type: 'startWorkflow',
 
   workflowType: string | Action;
-
-  /**
-   * Metadata that's propagated between workflows and activities? TODO someone explain headers to me so I can improve
-   * this apidoc and maybe:
-   * - remove from here and only expose to interceptor?
-   * - or make it Record<string, unknown> and apply client's data converter?
-   */
-  headers: Headers;
 };
 
 export type ScheduleActionType = Workflow;
@@ -1123,6 +1114,11 @@ interface ScheduleClientCallsInterceptor {
     input: ScheduleStartInput,
     next: Next<this, 'create'>
   ) => Promise<string /* conflictToken */>
+}
+
+interface ScheduleStartInput extends StartOptions {
+  ...StartOptions todo see other interceptors
+  headers: Headers
 }
 
 interface ScheduleClientCallsInterceptorFactoryInput {

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -606,47 +606,50 @@ export interface CalendarSpecDescription {
   /**
    * Valid values: 0–59
    *
-   * @default `[{ start: 0 }]`
+   * If the default input it used, the default output will be `[{}]`.
    */
   second?: NumberSpecDescription;
 
   /**
    * Valid values: 0–59
    *
-   * @default `[{ start: 0 }]`
+   * If the default input it used, the default output will be `[{}]`.
    */
   minute?: NumberSpecDescription;
 
   /**
    * Valid values: 0–59
    *
-   * @default `[{ start: 0 }]`
+   * If the default input it used, the default output will be `[{}]`.
    */
   hour?: NumberSpecDescription;
 
   /**
    * Valid values: 1–31
    *
-   * @default `[{ start: 1, end: 31 }]`
+   * If the default input it used, the default output will be `[{ start: 1, end: 31, step: 1 }]`.
    */
   dayOfMonth?: NumberSpecDescription;
+  // step will be 0/default over wire
 
   /**
-   * @default `[{ start: 'JANUARY' , end: 'DECEMBER' }]`
+   * If the default input it used, the default output will be `[{ start: 'JANUARY' , end: 'DECEMBER', step: 1 }]`.
    */
   month?: MonthSpecDescription;
+  // will get { start: 1, end: 12, step 0 } from server
 
   /**
    * Use full years, like `2030`
    *
-   * @default `undefined` (meaning any year)
+   * If the default input it used, the default output will be `undefined` (meaning any year).
    */
   year?: NumberSpecDescription;
 
   /**
-   * @default `[{ start: 'SUNDAY', end: 'SATURDAY' }]`
+   * If the default input it used, the default output will be `[{ start: 'SUNDAY', end: 'SATURDAY', step: 1 }]`.
    */
   dayOfWeek?: DaySpecDescription;
+  // will get { start: 0, end: 6, step 0 } from server
 
   /**
    * Description of the intention of this spec.

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -40,6 +40,7 @@ const schedule = await client.create({
     ],
     endAt: addWeeks(new Date(), 4),
     jitter: '30s',
+    timezone: 'US/Pacific',
   },
   action: {
     workflowId: 'wf-biz-id',
@@ -487,11 +488,11 @@ export enum ScheduleOverlapPolicy {
    * Allow any number of Actions to start immediately.
    *
    * This is the only policy under which multiple Actions can run concurrently.
-   *
-   * {@link lastCompletionResult} and {@link lastFailure} will not be available.
    */
   AllowAll,
 }
+
+checkExtends<temporal.api.enums.v1.schedule.ScheduleOverlapPolicy, ScheduleOverlapPolicy>();
 
 export interface Backfill {
   start: Date;
@@ -629,8 +630,7 @@ export type ZeroTo23 =
 
 export type Hour = Range<ZeroTo23> | ZeroTo23;
 
-export type ZeroTo30 =
-  | 0
+export type OneTo31 =
   | 1
   | 2
   | 3
@@ -660,11 +660,12 @@ export type ZeroTo30 =
   | 27
   | 28
   | 29
-  | 30;
+  | 30
+  | 31;
 
-export type DayOfMonth = Range<ZeroTo30> | ZeroTo30;
+export type DayOfMonth = Range<OneTo31> | OneTo31;
 
-export type ZeroTo11 = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
+export type OneTo12 = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 export type MonthName =
   | 'JAN'
@@ -691,7 +692,7 @@ export type MonthName =
   | 'DEC'
   | 'DECEMBER';
 
-export type MonthValue = ZeroTo11 | MonthName;
+export type MonthValue = OneTo12 | MonthName;
 
 export type Month = Range<MonthValue> | MonthValue;
 
@@ -941,9 +942,17 @@ export interface ScheduleSpec {
    */
   jitter?: Milliseconds;
 
+  /**
+   * IANA timezone name, for example `US/Pacific`.
+   * 
+   * https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+   * 
+   * @default UTC
+   */
+  timezone?: string;
+
   // Add to SDK if requested by users:
   //
-  // string timezone_name = 10;
   // bytes timezone_data = 11;
   //
   // Time zone to interpret all CalendarSpecs in.

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -20,20 +20,20 @@ const schedule = await client.create({
   id: 'schedule-biz-id',
   spec: {
     // every hour at minute 5
-    interval: {
+    intervals: [{
       every: '1h',
       at: '5m',
-    },
+    }],
     // every 20 days since epoch at day 2
-    // interval: {
+    // intervals: [{
     //   every: '20d',
     //   at: '2d'
-    // }
-    exclude: {
+    // }]
+    exclude: [{
       // skip 11:05 pm
       hour: 23,
       minute: 5,
-    },
+    }],
     endAt: addWeeks(new Date(), 4), 
     jitter: '30s',
     timezone: 'US/Eastern',

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -695,7 +695,8 @@ export interface IntervalSpecDescription {
 }
 
 /**
- * A complete description of a set of absolute times (possibly infinite) that an Action should occur at. These times
+ * A complete description of a set of absolute times (possibly infinite) that an Action should occur at.
+ * The times are the union of `calendars`, `intervals`, and `cronExpressions`, minus the `skip` times. These times
  * never change, except that the definition of a time zone can change over time (most commonly, when daylight saving
  * time policy changes for an area). To create a totally self-contained `ScheduleSpec`, use UTC.
  */
@@ -720,6 +721,29 @@ export interface ScheduleSpec {
    *   }, 'FRIDAY']
    * }
    * ```
+   *
+   * The string can have 5, 6, or 7 fields, separated by spaces, and they are interpreted in the
+   * same way as a {@link CalendarSpec}.
+   *
+   * - 5 fields:         minute, hour, day_of_month, month, day_of_week
+   * - 6 fields:         minute, hour, day_of_month, month, day_of_week, year
+   * - 7 fields: second, minute, hour, day_of_month, month, day_of_week, year
+   *
+   * Notes:
+   *
+   * - If year is not given, it defaults to *.
+   * - If second is not given, it defaults to 0.
+   * - Shorthands @yearly, @monthly, @weekly, @daily, and @hourly are also
+   * accepted instead of the 5-7 time fields.
+   * - @every <interval>[/<phase>] is accepted and gets compiled into an
+   * IntervalSpec instead. <interval> and <phase> should be a decimal integer
+   * with a unit suffix s, m, h, or d.
+   * - Optionally, the string can be preceded by CRON_TZ=<timezone name> or
+   * TZ=<timezone name>, which will get copied to {@link timezone}. (In which case the {@link timezone} field should be left empty.)
+   * - Optionally, "#" followed by a comment can appear at the end of the string.
+   * - Note that the special case that some cron implementations have for
+   * treating day_of_month and day_of_week as "or" instead of "and" when both
+   * are set is not implemented.
    */
   cronExpressions?: string[];
 
@@ -1110,3 +1134,24 @@ export interface ScheduleClientInterceptors {
   calls?: ScheduleClientCallsInterceptorFactory[]
 }
 ```
+
+- cron_string holds a traditional cron specification as a string. It
+- accepts 5, 6, or 7 fields, separated by spaces, and interprets them the
+- same way as CalendarSpec.
+- 5 fields: minute, hour, day_of_month, month, day_of_week
+- 6 fields: minute, hour, day_of_month, month, day_of_week, year
+- 7 fields: second, minute, hour, day_of_month, month, day_of_week, year
+- If year is not given, it defaults to \*. If second is not given, it
+- defaults to 0.
+- Shorthands @yearly, @monthly, @weekly, @daily, and @hourly are also
+- accepted instead of the 5-7 time fields.
+- Optionally, the string can be preceded by CRON_TZ=<timezone name> or
+- TZ=<timezone name>, which will get copied to timezone_name. (There must
+- not also be a timezone_name present.)
+- Optionally "#" followed by a comment can appear at the end of the string.
+- Note that the special case that some cron implementations have for
+- treating day_of_month and day_of_week as "or" instead of "and" when both
+- are set is not implemented.
+- @every <interval>[/<phase>] is accepted and gets compiled into an
+- IntervalSpec instead. <interval> and <phase> should be a decimal integer
+- with a unit suffix s, m, h, or d.

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -94,7 +94,7 @@ await schedule.delete();
 
 const { schedules, nextPageToken } = await client.listByPage({
   pageSize: 50,
-  nextPageToken: 'base64',
+  nextPageToken: 'string',
 });
 
 for await (const schedule: Schedule of client.list()) {
@@ -210,8 +210,6 @@ export interface ScheduleHandle {
   readonly client: ScheduleClient;
 }
 
-export type Base64 = string;
-
 export interface Schedule {
   /**
    * Schedule Id
@@ -244,7 +242,7 @@ export interface Schedule {
  * - the schedule may have been modified by {@link ScheduleHandle.update} or
  *   {@link ScheduleHandle.pause}/{@link ScheduleHandle.unpause}
  */
-export interface ScheduleDescription {
+export type ScheduleDescription = Schedule & {
   /** When Actions should be taken */
   spec: RequireAtLeastOne<ScheduleSpec, 'calendars' | 'intervals'>;
 
@@ -313,19 +311,18 @@ export interface ScheduleDescription {
 
 export interface ScheduleListPage {
   schedules: Schedule[];
-  nextPageToken?: Base64;
 
   /**
    * Token to use to when calling {@link ScheduleClient.listByPage}.
    *
    * If `undefined`, there are no more Schedules.
    */
-  nextPageToken?: Base64;
+  nextPageToken?: string;
 }
 
 export type WorkflowExecution = Required<temporal.api.common.v1.IWorkflowExecution>;
 
-export type ScheduleInfo = Schedule & {
+export interface ScheduleInfo {
   /** Number of Actions taken so far. */
   numActionsTaken: number;
   // TODO or numberOfActionsTaken etc?
@@ -358,7 +355,7 @@ export type ScheduleInfo = Schedule & {
   createdAt: Date;
   lastUpdatedAt: Date;
 
-  isValid(): boolean;
+  isValid: boolean;
 
   /** Error for invalid schedule. If this is present, no actions will be taken. */
   invalidScheduleError?: string;
@@ -898,12 +895,17 @@ export interface CalendarSpec {
  * instead.
  */
 export interface IntervalSpec {
-  every: Seconds;
+  /**
+   * Value is rounded to the nearest second.
+   */
+  every: Milliseconds;
 
   /**
+   * Value is rounded to the nearest second.
+   * 
    * @default 0
    */
-  at?: Seconds;
+  at?: Milliseconds;
 }
 
 /**
@@ -1118,7 +1120,7 @@ export interface ListScheduleOptions {
   pageSize?: number;
 
   /** Token to get the next page of results */
-  nextPageToken?: Base64;
+  nextPageToken?: string;
 }
 
 /**

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -40,9 +40,12 @@ const schedule = await client.create({
   },
   action: {
     startWorkflow: {
+      // type: WorkflowStartOptions & { workflowId: string }
       workflowId: 'biz-id',
       type: myWorkflow,
       args: ['sorry this is the only thing reused, chad 😄'],
+      // ... other WorkflowOptions
+      // https://typescript.temporal.io/api/interfaces/client.WorkflowOptions
     },
   },
   policies: {

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -17,7 +17,7 @@ import { myWorkflow } from './workflows'
 const client = new ScheduleClient()
 
 const schedule = await client.create({
-  id: 'biz-id',
+  id: 'schedule-biz-id',
   spec: {
     // every hour at minute 5
     interval: {
@@ -41,7 +41,7 @@ const schedule = await client.create({
   action: {
     startWorkflow: {
       // type: WorkflowStartOptions & { workflowId: string }
-      workflowId: 'biz-id',
+      workflowId: 'wf-biz-id',
       type: myWorkflow,
       args: ['sorry this is the only thing reused, chad 😄'],
       // ... other WorkflowOptions
@@ -72,6 +72,8 @@ const schedule = await client.create({
   memo,
   searchAttributes,
 })
+
+const schedule = await client.getHandle('schedule-biz-id')
 
 const scheduleDescription = await schedule.describe()
 

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -208,9 +208,7 @@ export interface ScheduleHandle {
    */
   describe(): Promise<ScheduleDescription>;
 
-  /**
-   * Get a handle to the most recent Action started
-   */
+  // we won't have this helper in TS because it involves an implicit client, but other SDKs may want this
   lastAction<T extends ScheduleActionType>(): Promise<HandleFor<T>>;
 
   /**

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -40,11 +40,10 @@ const schedule = await client.create({
   },
   action: {
     startWorkflow: {
-      // type: WorkflowStartOptions & { workflowId: string }
       workflowId: 'wf-biz-id',
       type: myWorkflow,
       args: ['sorry this is the only thing reused, chad 😄'],
-      // ... other WorkflowOptions
+      // ...WorkflowOptions + header - followRuns
       // https://typescript.temporal.io/api/interfaces/client.WorkflowOptions
     },
   },

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -42,7 +42,7 @@ const schedule = await client.create({
     startWorkflow: {
       workflowId: 'biz-id',
       type: myWorkflow,
-      input: ['sorry this is the only thing reused, chad 😄'],
+      args: ['sorry this is the only thing reused, chad 😄'],
     },
   },
   policies: {
@@ -72,7 +72,7 @@ const schedule = await client.create({
 
 const scheduleDescription = await schedule.describe()
 
-await schedule.listMatchingTimes({ start: new Date(), end: new Date() })
+const matchingStartTimes = await schedule.listMatchingTimes({ start: new Date(), end: new Date() })
 
 await schedule.update({
   spec,

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -72,7 +72,7 @@ const schedule = await client.create({
   searchAttributes,
 })
 
-const schedule = await client.getHandle('schedule-biz-id')
+const schedule = client.getHandle('schedule-biz-id')
 
 const scheduleDescription = await schedule.describe()
 

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -1110,15 +1110,16 @@ interface ScheduleClientCallsInterceptor {
   /**
    * Intercept a service call to CreateSchedule
    */
-  create?: (
-    input: ScheduleStartInput,
+  create?: <Action extends ScheduleActionType>(
+    input: CreateScheduleInput<Action>,
     next: Next<this, 'create'>
   ) => Promise<string /* conflictToken */>
 }
 
-interface ScheduleStartInput extends StartOptions {
-  ...StartOptions todo see other interceptors
-  headers: Headers
+/** Input for {@link ScheduleClientCallsInterceptor.create} */
+interface CreateScheduleInput<Action> {
+  readonly headers: Headers
+  readonly options: ScheduleOptions<Action>;
 }
 
 interface ScheduleClientCallsInterceptorFactoryInput {

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -581,8 +581,6 @@ export interface CalendarSpec {
    * @default 0
    */
   second?: Second | Second[] | '*';
-  // TODO or:
-  // second?: Second[];
 
   /**
    * @default 0

--- a/typescript/schedules.md
+++ b/typescript/schedules.md
@@ -54,8 +54,9 @@ const schedule = await client.create({
     timezone: 'US/Pacific',
   },
   action: {
+    type: 'startWorkflow',
     workflowId: 'wf-biz-id',
-    type: myWorkflow,
+    workflowType: myWorkflow,
     args: ['arg1', 'arg2'],
   },
   overlap: ScheduleOverlapPolicy.BUFFER_ONE,


### PR DESCRIPTION
Re: https://github.com/temporalio/sdk-features/issues/73

[rendered](https://github.com/temporalio/proposals/blob/schedules/typescript/schedules.md)

Some things I could add if helpful:

- types
- comments with the corresponding gRPC fields

I took minor liberties in choosing different terms for fields compared to gRPC. Downside is having a difference between SDK and tctl. But if we like SDK terms, maybe we submit a PR to tctl so it matches.

Also flattened / removed the `schedule` from `{ schedule:  { spec,  action, policies, state } }`. 

Note: you can hide comments for easier reading

<img width="452" alt="image" src="https://user-images.githubusercontent.com/251288/181700572-2de3b5e9-fbb6-4ab4-9683-9db4ddb21746.png">
