### PR TITLE
External client configuration proposal

### DIFF
--- a/all-sdk/external-client-configuration.md
+++ b/all-sdk/external-client-configuration.md
@@ -259,6 +259,14 @@ client = await Client.connect(namespace="my-specific-namespace", **config)
     * After discussion, it was decided future non-client use of this config (which may never occur) can be sub keys of
       this file instead of having a separate file or separate config for every separate use. And client is the common
       enough initial (and maybe only) use case to get the top-level without burdening users.
+* Unlike all other ways to provide settings, all file paths inside configuration files must be absolute or loading
+  should fail, no relative paths
+  * 💭 Why?
+    * We don't want to make paths relative to the config file, because people load this config into a common structure
+      and different meanings for different-sourced values (CLI vs env var vs config file vs programmatic) is confusing
+      and can't be represented well
+    * We're replacing `env set` with `config set` and the former supports relative to the calling user, so it'd be
+      confusing to change that
 
 ### Environment variables
 
@@ -344,7 +352,7 @@ is SDK specific).
         * This is the new way and we should not try to support both at the same time, it can get confusing.
   * The default is `default`, and this can also be set via `TEMPORAL_PROFILE` env var.
 * CLI will accept `--config-file`.
-  * Default is `~/.config/temporalio/temporal.toml`, also can be set via `TEMPORAL_CONFIG_FILE` env var.
+  * Has default specified before, also can be set via `TEMPORAL_CONFIG_FILE` env var.
 * CLI will have a whole new set of `config` commands that operate similar to `env` commands today.
   * Will not go into detail in this proposal, but it's very similar.
   * We will strictly validate keys when setting whereas we did not with `env`.

--- a/all-sdk/external-client-configuration.md
+++ b/all-sdk/external-client-configuration.md
@@ -1,0 +1,340 @@
+# External Client Configuration
+
+Notes for this proposal:
+
+* Everything is subject to change both during proposal time and afterwards during implementation.
+* For each place a decision is made, a "💭 Why X? ..." aside is present explaining why.
+* For each place an open question exists, a "❓ X?" exists to ask it.
+
+## Overview
+
+There are many ways to access Temporal programmatically including CLI, SDK, and other components that leverage those
+such as samples and Terraform providers.
+
+Temporal needs a way for users to provide client configuration without hardcoding in CLI arguments or SDK options. This
+will allow code to seamlessly switch between profiles such as between a dev-server and cloud. The same configuration
+must work across all SDKs/CLIs.
+
+### Goals
+
+* Common, well-specified configuration format usable by Temporal tooling for client options
+* Implementation in all Temporal SDKs for reading and writing of this configuration
+* All Temporal CLI/SDKs updated to have easy client creation using this configuration
+* Common on-disk location in every platform for reading/writing this format
+* Ability to provide environment variables to represent values in the configuration
+* Well-specified hierarchy for on-disk overridable by environment variables overridable by in-CLI/SDK values
+* 0 new dependencies in SDKs
+* Profile names within the configuration
+
+### Non-goals
+
+* Common format for declarative workers, schedules, etc. This is only for client options.
+* File-based hierarchy. We don't need many levels of file merging for these options at this time.
+* Extreme focus on human authoring of this format. This is because it'd likely go against the "0 new dependencies" rule.
+* Use external configuration by default. Users need to opt-in to this for compatibility and clarity reasons (but it is
+  of course easy).
+
+## Specification
+
+### Values and File Format
+
+* The format is a JSON object with the following fields:
+  * `profiles` - Object with keys as profile names. The default profile should be named `default`.
+    * `<name>` - Profile object with configuration values. Profile names are case-insensitive. 💭 Why? They are needed
+      for environment variables which are case insensitive. It is a validation error to have a config file with two
+      separately-cased profile names that are equal case-insensitively.
+      * `address` - Client address, aka gRPC "host:port".
+      * `namespace` - Client namespace.
+      * `apiKey` - Client API key.
+      * `tls` - A boolean (true is same as empty object) _or_ an object. Note the default for this value is dependent
+        upon the client and may change. 💭 Why? We regret not making TLS the default in the past. If TLS is an object,
+        it can have the following possible fields:
+        * `clientCertPath` - File path to mTLS client cert. Mutually exclusive with `clientCertData`.
+        * `clientCertData` - Cert data. Mutually exclusive with `clientCertPath`.
+        * `clientKeyPath` - File path to mTLS client key. Mutually exclusive with `clientKeyData`.
+        * `clientKeyData` - Key data. Mutually exclusive with `clientKeyPath`.
+        * `serverCaCertPath` - File path to server CA cert. Mutually exclusive with `serverCaCertData`.
+        * `serverCaCertData` - CA cert data. Mutually exclusive with `serverCaCertPath`.
+        * `serverName` - Override SNI name when connecting to server.
+        * `disableHostVerification` - Boolean to disable verifying TLS server host. May not be available in all Temporal
+          clients. 💭 Why? Not all SDKs offer this feature today.
+      * `codec` - Remote codec information to use for all encoding/decoding of payloads. May not be available in all
+        Temporal clients. 💭 Why? Not all SDKs allow use of a remote codec today.
+        * `endpoint` - Endpoint to the remote codec.
+        * `auth` - Authorization header for the remote codec.
+      * `grpcMeta` - Object representing HTTP headers. Values must be strings for now (can discuss arrays later).
+        ❓ Should we call this `headers`? We do in some cases and not others.
+  * 💭 Why JSON?
+    * Because YAML and TOML and others require a dependency in our SDKs. AWS for example has a homegrown INI-ish
+      implementation they have had to build in to every language.
+    * We accept that while JSON is technically human-authorable, it's not as easy as other formats. This is acceptable
+      since we will be providing tooling to mutate the config.
+    * ❓ Should we consider "json with comments" and some kind of very basic pre-parser in each language that strips
+      them? This could come later and not part of MVP.
+* This whole format will be defined in proto in the API repo in the `sdk` package.
+  * 💭 Why?
+    * Clear, centralized contract.
+    * Our SDKs already use proto dependency and this gives them stable JSON without requiring separate JSON dependency.
+    * Users can use the proto tooling to read/write configs programmatically since they are just proto JSON.
+* Do not validate that all keys are known in the file.
+  * 💭 Why?
+    * Originally this section was strict validation, but it became clear that we should allow newer-CLI-created config
+      files that may have newer keys to work with older SDKs.
+    * Similarly, it became clear that we're not validating environment variables this way, why config file keys?
+    * We want the tools that mutate this file to have strong validation on the keys being added, so hopefully this
+      avoids the concern of key typos.
+* All keys are optional in the file. Ideally in the final merged form, we'd always require `address` and we always
+  require `namespace` in namespace-specific clients (i.e. non cloud ops API), but it is unreasonable since we must fit
+  within SDK defaults.
+  * Originally this section did say `address` and `namespace` were required, but as SDK implementations came about, it
+    became clear that can't be done easily, so CLI/SDK defaults need to remain.
+* The default config file location is `~/.config/temporalio/temporal.json` for all platforms
+  * So in Windows this is often `C:\Users\MyUsername\.config\temporalio\temporal.json`
+  * ❓ Should we skip the subdir or make it `~/.config/temporal.json`? Unsure if there are any future files that would
+    go in here.
+  * Existing CLI used `~/.config/temporalio/temporal.yaml`
+    * ❓ Is this confusing for them? Are we concerned about them vs what is best moving forward?
+
+### Environment variables
+
+* Environment variables are in the form `TEMPORAL_<PROFILE_>_KEY_SUB_KEY_CAMEL_CASE`. If the profile part is missing,
+default is assumed.
+  * 💭 Why `TEMPORAL` prefix?
+    * Reasonable to differentiate.
+  * This means that `TEMPORAL_ADDRESS` and `TEMPORAL_DEFAULT_ADDRESS` are the same thing.
+  * This means that camel case parts are separated by underscores _except_ the profile name itself.
+    * So a config value of `profiles.myProfile.tls.clientCertPath` is `TEMPORAL_MYPROFILE_TLS_CLIENT_CERT_PATH`.
+    * 💭 Why?
+      * This is clearer for typing and it is unreasonable to try and break up user-supplied camel case.
+  * Also the profile may contain an underscore and retain that and match that first. So
+    `profiles.my_profile_tls.tls.clientCertPath` is `TEMPORAL_MY_PROFILE_TLS_TLS_CLIENT_CERT_PATH`.
+    * 💭 Why?
+      * It is unreasonable to elide any characters in the user-provided profile name.
+* Environment variables are case-insensitive.
+* The CLI has existing environment variables. Some of these work and some should be still supported but deprecated in
+  favor of the new forms. Below are the CLI env vars and how they apply:
+  * `TEMPORAL_ADDRESS` - works just fine.
+  * `TEMPORAL_NAMESPACE` - works just fine.
+  * `TEMPORAL_API_KEY` - works just fine.
+  * `TEMPORAL_TLS` - works just fine.
+  * `TEMPORAL_TLS_CERT`, `TEMPORAL_TLS_CERT_DATA`, and other mTLS client values - need to be deprecated and replaced
+    with newer forms (only slight changes here).
+    * 💭 Why not just have the `tls` config field be `certData` instead of `clientCertData` so this doesn't have to
+      change?
+      * Not being clear this is for mTLS client use is confusing to users. And we'd have to change the path one anyways
+        because the CLI is not suffixed with path.
+  * `TEMPORAL_TLS_X` for all other values - ones that don't match need to be deprecated and replaced with newer forms.
+  * `TEMPORAL_CODEC_ENDPOINT` - works just fine.
+  * `TEMPORAL_CODEC_AUTH` - works just fine.
+  * 💭 Why deprecate some instead of making all our clients support these variables that exist in CLI?
+    * It is more sane/reasonable to have a simple to understand config-field-to-env-var format than it is to have these
+      special environment variables be inconsistent outliers.
+    * For non-CLI uses (i.e. SDKs), it is unreasonable to burden them with past CLI choices.
+* There are some special environment variables respected by clients:
+  * `TEMPORAL_PROFILE` - the name of the profile to load if one is not provided at load time. The default is  `default`.
+  * `TEMPORAL_CONFIG_FILE` - the path to the config file. The default is `~/.config/temporalio/temporal.json`.
+* ❓ How do to grpc-meta as env var? Like for `My-Header: My-Value`
+  * Env var names are case-insensitive and don't use dashes, so we can't put header name in env var name. And we may not
+    want to canonicalize the header names even though most gRPC clients do it for you.
+  * There's no obvious env var approach to array of strings, and it can't be completely comma-delimited because header
+    values often contain commas. Would rather not force users to have an index in the env var name. Should we just not
+    support gRPC meta from env var until we think this through?
+
+## Implementation
+
+### CLI
+
+* CLI will accept `--profile`.
+  * This deprecates `--env`/`--env-file`
+    * 💭 Why deprecate?
+      * The `env` name is confusing with environment variables. Note we do not use the term "environment" anywhere in
+        this document except for environment variables.
+      * The `env` setting uses YAML files in `~/.config/temporalio/temporal.yaml`.
+    * Error if both options are present, or in the case of default, if there are default files for both.
+      * 💭 Why error in the case of both default env and profile being present instead of merge?
+        * This is the new way and we should not try to support both at the same time, it can get confusing.
+  * The default is `default`, and this can also be set via `TEMPORAL_PROFILE` env var.
+* CLI will accept `--config-file`.
+  * Default is `~/.config/temporalio/temporal.json`, also can be set via `TEMPORAL_CONFIG_FILE` env var.
+* CLI will have a whole new set of `profile` commands that operate similar to `env` commands today.
+  * Will not go into detail in this proposal, but it's very similar.
+  * We will strictly validate keys when setting whereas we did not with `env`.
+* Unlike `env`/`--env`, this does not blindly apply any field as any CLI argument.
+  * 💭 Why?
+    * We want strict validation of config values. The idea that you can set a `workflow-id` as part of this profile does
+      not make sense. These are client options only, declarative options for other things can be discussed separately.
+* CLI should defer to the Go SDK for loading/using the config/profile.
+
+### SDKs
+
+SDKs must support loading client configuration from optional profile name and optional config name. This needs to
+include a way to make sure that user-defaults can be set.
+
+Possible language-specific ideas are below. Note, they are not exact and the naming is all subject to change, they are
+simply ideas for discussion. Many of the approaches below are based on several rewritings after seeing how they don't
+work in some SDKs. The overall approach is to just make client and connection options loadable from configuration
+without overthinking shortcuts or merging or hierarchies.
+
+#### Go SDK Idea
+
+Some decisions here are explained here even though they apply to later SDKs. 
+
+* New function in `client`: `LoadConfig(LoadConfigOptions) (*proto.Config, error)`.
+  * This is mostly a helper if people want it.
+* `LoadConfigOptions` has the following:
+  * `ConfigFile string` - Override the file to use.
+  * `DisableFile bool` - Disable reading from file.
+  * `DisableEnv bool` - Disable reading from env vars.
+* New function in `client`: `LoadOptionsFromConfig(string profile, LoadConfigOptions) (Options, error)`.
+  * 💭 Why require profile, isn't there a default of `default`?
+    * Yes, and maybe that's what empty string is too, but in general Go doesn't have good parameter defaults and we
+      don't want a differently named overload just for this.
+* New function in `client`: `NewOptionsFromConfig(*proto.ConfigProfile) (Options, error)`.
+  * 💭 Why is this needed if `LoadOptionsFromConfig` exists?
+    * People need a way to provide the config to load from instead of always assuming it can be loaded.
+  * 💭 Why not have the config proto to use in the `LoadConfigOptions` instead?
+    * It gets to be a bit of a merge game if you have a `BaseConfig` there, and it's a bit confusing if you have
+      `PreloadedConfig` there which implies all other options don't matter.
+* 💭 Why not just have the load config options on the client options and let dialing load?
+  * People need to adjust options _after_ loaded (overwrite defaults, etc).
+* 💭 Why not have `(*Options).LoadFromConfig` helper method on the options instead?
+  * The merging logic gets far too complicated to know what to overwrite and what not to. It's better to force the user
+    to start from config and handle merging themselves if they need that.
+* Go SDK _does_ support codec settings because it supports remote codecs.
+  * If the remote codec setting is set, the data converter option will be set.
+  * 💭 Why not have a `PayloadCodecFromConfig` type of thing?
+    * This is easy enough for users to do with the `LoadConfig` helper and the remote codec objects.
+    * Most won't need it because regular `LoadOptionsFromConfig` creates it with default payload conversion. Only those
+      that need customized payload conversion will need to create the remote codec themselves.
+* Options like grpc-meta sets header provider, API key sets credentials, etc.
+  * 💭 Why make a user that just wants to _add_ a header on top of config have to use `LoadConfig` and do it the hard
+    way?
+    * There's no clean way to support single header adding on top of existing ones in the Go SDK today.
+
+Simplest example:
+
+```go
+options, err := client.LoadOptionsFromConfig("default")
+if err != nil {
+  return err
+}
+cl, err := client.Dial(options)
+```
+
+#### Java SDK Idea
+
+* New static `ServiceStubsOptions.loadConfig()` and
+  `ServiceStubsOptions.loadConfig(@Nullable String configFile, boolean disableFile, boolean disableEnv)` that return the
+  full protobuf `Config` object.
+  * ❓Any better place to put this? It's a proto utility, not a service stub utility.
+* New static `WorkflowServiceStubsOptions.loadBuilderFromConfig()` and
+  `WorkflowServiceStubsOptions.loadBuilderFromConfig(@Nullable String profile, @Nullable configFile, ` +
+  `boolean disableFile, boolean disableEnv)` and
+  `WorkflowServiceStubsOptions.newBuilderFromConfig(ConfigProfile profile)`.
+  * 💭 Why not have these loaders as instance methods on the builder?
+    * Same reason as Go, because the merging logic of knowing what to do with existing data is too complicated and it's
+      best for the user to do that as needed.
+* Need the same for operator and cloud service stubs options.
+* Need same methods for `WorkflowClientOptions`.
+  * Unfortunately with how Java works, there are separate client options, and they too can be in config.
+  * ❓ Any alternative suggestions here? We could have some kind of shortcut to do multiple steps here.
+* ❓ Does Java have a concept of a remote codec?
+
+Simplest example:
+
+```java
+var stubsOptions = WorkflowServiceStubsOptions.loadBuilderFromConfig().build();
+var stubs = WorkflowServiceStubs.newServiceStubs(stubsOptions);
+var clientOptions = WorkflowClientOptions.loadBuilderFromConfig().build();
+var client = WorkflowClient.newInstance(stubs, clientOptions);
+```
+
+#### TypeScript SDK Idea
+
+* New `client` module function `loadConfig(options?)` where the `options` type is
+  `{ configFile?: string, disableFile?: bool, disableEnv?: bool }` and it returns a `proto.Config`.
+* New `client` module function `loadOptionsFromConfig(options?)` where the optional `options` are
+  either `proto.ConfigProfile` or `{ profile?: string, configFile?: string, disableFile?: bool, disableEnv?: bool }` and
+  it returns a `ConnectionOptions & ClientOptions`.
+  * Could also have it return `{ connectionOptions: ConnectionOptions, clientOptions: ClientOptions }` if that makes
+    more sense than a union.
+* Consider a new async `Client.connect` static method that accepts `ConnectionOptions & ClientOptions` and is a
+  shortcut to the two-step process today.
+* TypeScript SDK _does not_ support codec settings and will error if seen in config.
+  * 💭 Why error?
+    * Because a user with a profile configured with a codec should expect that codec to be used, not silently ignored.
+
+Simplest example:
+
+```typescript
+const options = loadOptionsFromConfig();
+const connection = Connection.connect(options);
+const client = new Client({ connection, ...options });
+
+// Or maybe:
+
+const { connectionOptions, clientOptions } = loadOptionsFromConfig();
+const connection = Connection.connect(connectionOptions);
+const client = new Client({ connection, ...clientOptions });
+```
+
+#### Python SDK Idea
+
+* In `service` module, new function `load_config` with kwarg parameters of `config_file: Optional[str] = None`,
+  `disable_file: bool = False`, `disable_env: bool = False` and it returns a `proto.Config`.
+* In `service` module, new static method `ConnectConfig.load_from_config` with positional parameter of
+  `profile: str = 'default'` and kwarg parameters of `config_file: Optional[str] = None`, `disable_file: bool = False`,
+  and `disable_env: bool = False` and it returns a `ConnectConfig`.
+* In `service` module, new static method `ConnectConfig.from_config` that accepts a single positional parameter of
+  `proto.ConfigProfile`.
+* In `client` module, new static methods for `ClientConfig.load_from_config` and `ClientConfig.from_config` same as
+  above two for service module.
+* In `client` module, new `TypedDict` class called `ClientConnectConfig` that extends `ClientConfig` but adds all the
+  other parameters for `connect`.
+  * On that class, new static methods for `load_from_config` and `from_config` that are like the others.
+  * This config can mutated and splatted as the args to `Client.connect`.
+    * 💭 Why not a separate `connect` call purely for config?
+      * Many users want to set other options after config loads, and like with other SDKs adding config loading at the
+        same time has option setting has many merge problems, so we need them to be separate steps.
+* Like TypeScript, Python SDK _does not_ support codec settings and will error if seen in config.
+
+Simplest example:
+
+```python
+config = ClientConnectConfig.load_from_config()
+client = await Client.connect(**config)
+```
+
+#### .NET SDK Idea
+
+* New static methods on `TemporalConnectionOptions` for `LoadConfig()` and
+  `LoadConfig(string? configFile, bool disableFile, bool disableEnv)` and it returns `proto.Config`.
+  * ❓Like Java, any better place to put this? It's a proto utility, not an options utility.
+* New static methods on `TemporalConnectionOptions` for `LoadFromConfig()`,
+  `LoadFromConfig(string profile = "default", string? configFile, bool disableFile, bool disableEnv)`.
+  and `LoadFromConfig(proto.ConfigProfile)` that all return `TemporalConnectionOptions`.
+* Same static methods on `TemporalClientConnectOptions`.
+* Same static methods on `TemporalClientOptions`.
+* Like TypeScript, .NET SDK _does not_ support codec settings and will error if seen in config.
+
+Simples example:
+
+```csharp
+var options = TemporalClientConnectOptions.LoadFromConfig();
+var client = await TemporalClient.ConnectAsync(options);
+```
+
+### Samples
+
+* All samples will be updated to load from config and default to local dev server w/ default namespace.
+  * In samples we try to avoid shared code. In .NET and Python, there is no default target host, and in Ruby there will
+    not even be a default namespace. So every sample in these languages is going to have to not only have the
+    load-from-config code, but also conditionally apply the target host as `localhost:7233` if not set in external
+    config.
+
+### UI
+
+* The UI could offer, say on API key creation, the ability to download a config file for use.
+  * Since we require all profiles in a single file in the default place, the downloaded file would be just including the
+    `default` profile and the instructions would tell them where to place it or they could provide this config file
+    in any client at connection option time.


### PR DESCRIPTION
# Summary

* This is the proposal for external client configuration (i.e. config files and profiles)
* See it [rendered](https://github.com/cretz/temporal-proposals/blob/external-client-configuration/all-sdk/external-client-configuration.md)
* This is the second round of review (see #94 for the first)
* Like other proposals, all feedback welcome. If the PR discussion gets too large or the review round comes to an end w/ more review needed, it will be closed and a new one will be created referencing this one.

Notable changes since first round:

* Added more usage examples including making configuration files more prominent
* Removed the concept of profile-specific environment variables
* Changed the default config filename to make it clear it's not for all config that may ever happen, just for clients
* Switched file format to TOML
* Changed SDKs to use "extension" approach since they'll need a new TOML dependency (there are some outstanding questions here regarding whether to use Rust Core)
* Added env var support for gRPC headers